### PR TITLE
feat: Step B — schema / validator / generator (0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-02
+
+### Added
+
+- `core_harness.schema`:
+  - `framework_schema.json` — Layer 1 SOT JSON Schema for the per-role
+    permission/hook configuration. Type-only: no role names, no
+    consumer-specific patterns.
+  - `load_framework_schema()`, `framework_schema_path()`,
+    `merge_schemas(framework, org_extension)`.
+- `core_harness.validator`:
+  - `validate_settings(settings, framework, org_extension, *, role)` —
+    top-level entry returning a `ValidationResult`.
+  - Lower-level engine: `validate_config`, `validate_schema_integrity`,
+    `extract_role_blocks`, `check_worker_settings`,
+    `matches_worker_template`.
+  - Result types: `Finding`, `ValidationResult`.
+- `core_harness.generator`:
+  - `generate_settings(role, worker_dir, framework, org_extension, *,
+    consumer_root=None, extra_placeholders=None)` — top-level entry.
+  - `render_role(schema, role, **placeholders)` — direct template
+    renderer with org-neutral placeholder support.
+- Test suites: `tests/test_validator.py`, `tests/test_generator.py`
+  (synthetic fixtures only — no consumer-org strings).
+
+### Changed
+
+- Promoted Development Status classifier from `2 - Pre-Alpha` to
+  `3 - Alpha`.
+- `core_harness.validator.validate_schema` placeholder removed in
+  favour of `validate_settings` (real implementation).
+- `core_harness.generator.generate_settings` placeholder replaced with
+  the real implementation; signature is the new public surface.
+
+### Notes
+
+- Placeholders are now neutral: `{worker_dir}`, `{consumer_root}`, and
+  any caller-supplied alias via `extra_placeholders`. Consumers that
+  used `{claude_org_path}` keep working by passing it as an
+  `extra_placeholders` alias of `consumer_root`.
+- `core_harness.hooks` and `core_harness.audit` remain placeholders;
+  Step C / Step D land in subsequent 0.x releases.
+
 ## [0.0.1] - 2026-05-02
 
 ### Added

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -1,32 +1,72 @@
 # Public API Surface — 0.x
 
-> **Status: TBD.** This document tracks the evolving public surface during
-> the pre-1.0 phase. Items here are not stable and may change between minor
-> versions per [`semver-policy.md`](semver-policy.md).
+> **Status: 0.1.0 published.** This document tracks the evolving public
+> surface during the pre-1.0 phase. Items below are *experimental*
+> unless explicitly marked `stable`; signatures may change between
+> minor versions per [`semver-policy.md`](semver-policy.md).
 
 ## Modules
 
-| Module | Status | Notes |
+| Module | Status (0.1) | Notes |
 |---|---|---|
-| `core_harness.schema` | placeholder | Framework schema (Layer 1 SOT). Will host type definitions for `forbidden_allow_*`, `required_hook_scripts`, etc. |
-| `core_harness.validator` | placeholder | `validate_schema(...)` — raises `NotImplementedError` in 0.0.1. |
-| `core_harness.generator` | placeholder | `generate_settings(...)` — raises `NotImplementedError` in 0.0.1. |
-| `core_harness.hooks` | placeholder | `HookRunner` protocol. Hook script paths are configurable; default paths TBD. |
-| `core_harness.audit` | placeholder | `Journal` protocol. |
+| `core_harness.schema` | experimental | Framework JSON Schema + merge helper. Type-only — concrete role names / consumer regexes live in the org-extension schema (PR #196 §3). |
+| `core_harness.validator` | experimental | Audit engine for per-role `settings.local.json`. |
+| `core_harness.generator` | experimental | Worker `settings.local.json` template renderer. |
+| `core_harness.hooks` | placeholder | Hook framework lib (Step C). |
+| `core_harness.audit` | placeholder | Journal API (Step D). |
+
+## Public symbols (0.1)
+
+### `core_harness.schema`
+
+| Symbol | Status | Purpose |
+|---|---|---|
+| `load_framework_schema() -> dict` | experimental | Return the framework JSON Schema (deep copy). |
+| `framework_schema_path() -> Path` | experimental | On-disk path to the framework JSON file. |
+| `merge_schemas(framework: dict \| None, org_extension: dict) -> dict` | experimental | Merge framework defaults with org-extension; result has `global`, `required_hook_scripts`, `roles`, `worker_roles` always present. |
+
+### `core_harness.validator`
+
+| Symbol | Status | Purpose |
+|---|---|---|
+| `validate_settings(settings, framework, org_extension, *, role, ...) -> ValidationResult` | experimental | Top-level entry. |
+| `validate_config(source, role, config, role_schema, global_schema, *, extra_allowed=None) -> list[Finding]` | experimental | Single-role audit. |
+| `validate_schema_integrity(schema) -> list[Finding]` | experimental | `required_hook_scripts` cross-check. |
+| `extract_role_blocks(md_text, roles) -> dict` | experimental | Pull JSON blocks from a docs projection. |
+| `check_worker_settings(schema, base_dir) -> list[Finding]` | experimental | Drift-check `<base_dir>/*/.claude/settings.local.json`. |
+| `matches_worker_template(config, template, *, expected_worker_dir=None) -> bool` | experimental | Placeholder-consistent template match. |
+| `Finding(source, role, severity, message)` | experimental | Result entry. |
+| `ValidationResult(findings)` | experimental | Aggregated result with `.ok`. |
+
+### `core_harness.generator`
+
+| Symbol | Status | Purpose |
+|---|---|---|
+| `generate_settings(role, worker_dir, framework, org_extension, *, consumer_root=None, extra_placeholders=None) -> dict` | experimental | Top-level entry. |
+| `render_role(schema, role, **placeholders) -> dict` | experimental | Render a single `worker_roles` template. |
+
+### Placeholders recognised by the generator
+
+- `{worker_dir}` — absolute path to the worker's worktree.
+- `{consumer_root}` — absolute path to the consuming repo (org-neutral
+  rename of the legacy `{claude_org_path}`).
+- Arbitrary names supplied via `extra_placeholders={...}` for legacy
+  alias support (e.g. consumers may pass `{claude_org_path}` pointing
+  at the same value as `consumer_root`).
 
 ## 1.0 graduation conditions
 
-See [`semver-policy.md`](semver-policy.md) for the full criteria. In short:
+See [`semver-policy.md`](semver-policy.md). In short:
 
-- Two consumers, one month, no breaks.
-- Two consecutive minors with no breaking changes.
-- All entries above marked `stable` (no remaining `placeholder` /
-  `experimental` for items intended for 1.0).
+- ≥ 2 external consumers (real schemas, not forks/stars).
+- ≥ 2 consecutive minor releases with no breaking changes.
+- All entries above marked `stable`; no remaining `placeholder` /
+  `experimental` for items intended for 1.0.
 
 ## Conventions used in this document
 
 - **placeholder** — symbol exists for import-time stability; calling it
   raises `NotImplementedError`.
-- **experimental** — implemented but signature/semantics likely to change.
-- **stable** — signature is committed; breaking change requires a major bump
-  post-1.0, or a deprecation window pre-1.0.
+- **experimental** — implemented but signature/semantics may change.
+- **stable** — signature is committed; breaking change requires a
+  major bump post-1.0, or a deprecation window pre-1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "core-harness"
-version = "0.0.1"
+version = "0.1.0"
 description = "Reusable safety primitives for Claude Code orchestrator harnesses"
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "suisya-systems", email = "iwama.ryo.0731@gmail.com" }]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
 ]
@@ -22,3 +22,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"core_harness.schema" = ["framework_schema.json"]

--- a/src/core_harness/__init__.py
+++ b/src/core_harness/__init__.py
@@ -2,8 +2,49 @@
 
 Layer 1 of the claude-org architecture. See README.md and
 docs/canonical-ownership.md.
+
+Public surface (0.1, see docs/api-surface-v0.x.md):
+
+* ``core_harness.schema``    — framework JSON Schema + merge helper.
+* ``core_harness.validator`` — settings.local.json audit engine.
+* ``core_harness.generator`` — worker_role template renderer.
 """
 
-__version__ = "0.0.1"
+from core_harness.generator import generate_settings, render_role
+from core_harness.schema import (
+    framework_schema_path,
+    load_framework_schema,
+    merge_schemas,
+)
+from core_harness.validator import (
+    Finding,
+    ValidationResult,
+    check_worker_settings,
+    extract_role_blocks,
+    matches_worker_template,
+    validate_config,
+    validate_schema_integrity,
+    validate_settings,
+)
 
-__all__ = ["__version__"]
+__version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    # schema
+    "load_framework_schema",
+    "framework_schema_path",
+    "merge_schemas",
+    # validator
+    "Finding",
+    "ValidationResult",
+    "validate_settings",
+    "validate_config",
+    "validate_schema_integrity",
+    "extract_role_blocks",
+    "check_worker_settings",
+    "matches_worker_template",
+    # generator
+    "generate_settings",
+    "render_role",
+]

--- a/src/core_harness/generator/__init__.py
+++ b/src/core_harness/generator/__init__.py
@@ -7,15 +7,18 @@ template by substituting placeholders such as ``{worker_dir}`` and
 
 Public surface (0.1):
 
-* :func:`generate_settings` — top-level entry point.
-* :func:`render_role`       — render a worker_roles template against a
-  placeholder mapping.
+* :func:`generate_settings`         — top-level entry point.
+* :func:`render_role`               — render a worker_roles template
+  against a placeholder mapping.
+* :exc:`UnresolvedPlaceholderError` — raised when output still
+  contains ``{name}`` placeholders.
 
 See PR #196 §3.1 / §4 Step B for the placeholder rename rationale.
 """
 
 from __future__ import annotations
 
+import re
 from copy import deepcopy
 from typing import Any
 
@@ -24,6 +27,22 @@ from core_harness.schema import merge_schemas
 # Keys under worker_roles[<role>] that are metadata, not part of the
 # emitted settings.local.json content.
 _META_KEYS = {"description", "$comment"}
+
+# Anything that looks like a placeholder token: ``{name}`` with an
+# identifier-shaped name. Used as a fail-closed gate so an unsubstituted
+# ``{consumer_root}`` cannot silently slip into a generated settings file
+# (which would render hook command paths inert and bypass Layer 1
+# enforcement).
+_PLACEHOLDER_TOKEN = re.compile(r"\{[a-zA-Z_][a-zA-Z0-9_]*\}")
+
+
+class UnresolvedPlaceholderError(ValueError):
+    """Raised when generator output still contains ``{name}`` placeholders.
+
+    Layer 1 must fail closed on unsubstituted placeholders: an unresolved
+    ``{consumer_root}`` in a hook command silently disables the hook
+    rather than producing a useful error at runtime.
+    """
 
 
 def _substitute(value: Any, mapping: dict) -> Any:
@@ -39,6 +58,22 @@ def _substitute(value: Any, mapping: dict) -> Any:
     return value
 
 
+def _collect_unresolved(value: Any, path: str = "$") -> list:
+    """Walk ``value`` and return ``(path, token)`` for every leftover
+    ``{name}`` placeholder."""
+    out: list = []
+    if isinstance(value, str):
+        for m in _PLACEHOLDER_TOKEN.finditer(value):
+            out.append((path, m.group(0)))
+    elif isinstance(value, list):
+        for i, v in enumerate(value):
+            out.extend(_collect_unresolved(v, f"{path}[{i}]"))
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            out.extend(_collect_unresolved(v, f"{path}.{k}"))
+    return out
+
+
 def render_role(schema: dict, role: str, **placeholders: str) -> dict:
     """Return the settings dict for ``role`` from ``schema['worker_roles']``.
 
@@ -47,8 +82,10 @@ def render_role(schema: dict, role: str, **placeholders: str) -> dict:
     consumer_root="/abs/co")`` replaces every ``{worker_dir}`` /
     ``{consumer_root}`` token.
 
-    Raises :class:`KeyError` for unknown roles or for reserved metadata
-    keys (``$comment``).
+    Raises :class:`KeyError` for unknown / reserved roles, and
+    :class:`UnresolvedPlaceholderError` when the rendered output still
+    contains ``{name}`` placeholders (fail closed — Layer 1 does not
+    emit half-substituted hook commands).
     """
     roles = schema.get("worker_roles") or {}
     available = sorted(
@@ -57,7 +94,16 @@ def render_role(schema: dict, role: str, **placeholders: str) -> dict:
     if role not in roles or role.startswith("$") or not isinstance(roles[role], dict):
         raise KeyError(f"unknown worker role: {role!r}. available: {available}")
     template = {k: v for k, v in roles[role].items() if k not in _META_KEYS}
-    return _substitute(deepcopy(template), placeholders)
+    rendered = _substitute(deepcopy(template), placeholders)
+    leftovers = _collect_unresolved(rendered)
+    if leftovers:
+        joined = ", ".join(f"{path}={tok}" for path, tok in leftovers[:5])
+        raise UnresolvedPlaceholderError(
+            f"unresolved placeholders in worker_roles[{role!r}]: {joined}"
+            + (" ..." if len(leftovers) > 5 else "")
+            + ". Pass them via the placeholders/extra_placeholders argument."
+        )
+    return rendered
 
 
 def generate_settings(
@@ -87,4 +133,4 @@ def generate_settings(
     return render_role(merged, role, **placeholders)
 
 
-__all__ = ["generate_settings", "render_role"]
+__all__ = ["generate_settings", "render_role", "UnresolvedPlaceholderError"]

--- a/src/core_harness/generator/__init__.py
+++ b/src/core_harness/generator/__init__.py
@@ -1,10 +1,90 @@
-"""Settings generator. 0.0.1 placeholder; implementation lands in 0.1+."""
+"""Worker ``settings.local.json`` generator (Layer 1 SOT).
 
+Renders a concrete ``settings.local.json`` payload from a worker_roles
+template by substituting placeholders such as ``{worker_dir}`` and
+``{consumer_root}`` (the org-neutral name; the consumer's previous
+``{claude_org_path}`` is supported as an alias).
+
+Public surface (0.1):
+
+* :func:`generate_settings` — top-level entry point.
+* :func:`render_role`       — render a worker_roles template against a
+  placeholder mapping.
+
+See PR #196 §3.1 / §4 Step B for the placeholder rename rationale.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
 from typing import Any
 
+from core_harness.schema import merge_schemas
 
-def generate_settings(*args: Any, **kwargs: Any) -> None:
-    raise NotImplementedError("generate_settings is a 0.0.1 placeholder; lands in 0.1+")
+# Keys under worker_roles[<role>] that are metadata, not part of the
+# emitted settings.local.json content.
+_META_KEYS = {"description", "$comment"}
 
 
-__all__ = ["generate_settings"]
+def _substitute(value: Any, mapping: dict) -> Any:
+    if isinstance(value, str):
+        out = value
+        for placeholder, replacement in mapping.items():
+            out = out.replace("{" + placeholder + "}", replacement)
+        return out
+    if isinstance(value, list):
+        return [_substitute(v, mapping) for v in value]
+    if isinstance(value, dict):
+        return {k: _substitute(v, mapping) for k, v in value.items()}
+    return value
+
+
+def render_role(schema: dict, role: str, **placeholders: str) -> dict:
+    """Return the settings dict for ``role`` from ``schema['worker_roles']``.
+
+    ``placeholders`` provides string substitutions; e.g.
+    ``render_role(schema, "default", worker_dir="/abs/wd",
+    consumer_root="/abs/co")`` replaces every ``{worker_dir}`` /
+    ``{consumer_root}`` token.
+
+    Raises :class:`KeyError` for unknown roles or for reserved metadata
+    keys (``$comment``).
+    """
+    roles = schema.get("worker_roles") or {}
+    available = sorted(
+        k for k, v in roles.items() if not k.startswith("$") and isinstance(v, dict)
+    )
+    if role not in roles or role.startswith("$") or not isinstance(roles[role], dict):
+        raise KeyError(f"unknown worker role: {role!r}. available: {available}")
+    template = {k: v for k, v in roles[role].items() if k not in _META_KEYS}
+    return _substitute(deepcopy(template), placeholders)
+
+
+def generate_settings(
+    role: str,
+    worker_dir: str,
+    framework_schema: dict | None,
+    org_extension_schema: dict,
+    *,
+    consumer_root: str | None = None,
+    extra_placeholders: dict | None = None,
+) -> dict:
+    """Top-level generator entry point.
+
+    Merges ``framework_schema`` with ``org_extension_schema``, locates
+    ``worker_roles[role]`` in the merged dict, and renders it with
+    ``{worker_dir}`` / ``{consumer_root}`` substituted. ``extra_placeholders``
+    lets the caller supply additional org-specific aliases (e.g.
+    ``{claude_org_path}``) that point at the same value as
+    ``consumer_root``.
+    """
+    merged = merge_schemas(framework_schema, org_extension_schema)
+    placeholders: dict = {"worker_dir": worker_dir}
+    if consumer_root is not None:
+        placeholders["consumer_root"] = consumer_root
+    if extra_placeholders:
+        placeholders.update(extra_placeholders)
+    return render_role(merged, role, **placeholders)
+
+
+__all__ = ["generate_settings", "render_role"]

--- a/src/core_harness/schema/__init__.py
+++ b/src/core_harness/schema/__init__.py
@@ -20,11 +20,22 @@ See PR #196 §3 for the framework / org-extension split, and
 from __future__ import annotations
 
 import json
+import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 _FRAMEWORK_SCHEMA_PATH = Path(__file__).resolve().parent / "framework_schema.json"
+
+
+class SchemaError(ValueError):
+    """Raised when an org-extension schema violates the framework's
+    structural contract.
+
+    Layer 1 fails closed: a typo in ``forbidden_allow_regex`` or a
+    misshapen ``roles`` entry must surface as an error rather than
+    silently degrading to an empty audit constraint set.
+    """
 
 
 def load_framework_schema() -> dict:
@@ -42,9 +53,102 @@ def framework_schema_path() -> Path:
     return _FRAMEWORK_SCHEMA_PATH
 
 
+def _require_list_of_str(value: Any, dotted_path: str) -> None:
+    if not isinstance(value, list):
+        raise SchemaError(f"{dotted_path} must be a list, got {type(value).__name__}")
+    for i, entry in enumerate(value):
+        if not isinstance(entry, str):
+            raise SchemaError(
+                f"{dotted_path}[{i}] must be a string, got {type(entry).__name__}"
+            )
+
+
+def _validate_extension_structure(ext: dict) -> None:
+    """Fail-closed structural check of an org-extension schema.
+
+    This is *not* a full JSON Schema validator (we deliberately avoid
+    a runtime ``jsonschema`` dependency in pre-1.0). It does enforce
+    the contract points whose silent failure would weaken Layer 1
+    audit guarantees: list-of-string types under ``global``,
+    ``required_hook_scripts``, and the per-role string-list fields.
+    """
+    if not isinstance(ext, dict):
+        raise SchemaError(f"org_extension_schema must be a dict, got {type(ext).__name__}")
+
+    g = ext.get("global")
+    if g is not None:
+        if not isinstance(g, dict):
+            raise SchemaError(f"global must be a dict, got {type(g).__name__}")
+        for key in ("forbidden_allow_exact", "forbidden_allow_regex"):
+            if key in g:
+                _require_list_of_str(g[key], f"global.{key}")
+        for pat in g.get("forbidden_allow_regex", []):
+            try:
+                re.compile(pat)
+            except re.error as exc:
+                raise SchemaError(
+                    f"global.forbidden_allow_regex contains invalid regex {pat!r}: {exc}"
+                ) from exc
+
+    if "required_hook_scripts" in ext:
+        _require_list_of_str(ext["required_hook_scripts"], "required_hook_scripts")
+
+    roles = ext.get("roles")
+    if roles is not None:
+        if not isinstance(roles, dict):
+            raise SchemaError(f"roles must be a dict, got {type(roles).__name__}")
+        for role_name, role in roles.items():
+            if not isinstance(role, dict):
+                raise SchemaError(
+                    f"roles[{role_name!r}] must be a dict, got {type(role).__name__}"
+                )
+            for key in (
+                "required_allow",
+                "allowed_allow_regex",
+                "required_deny",
+                "disallow_allow_regex",
+                "settings_paths",
+            ):
+                if key in role:
+                    _require_list_of_str(role[key], f"roles[{role_name!r}].{key}")
+            for key in ("allowed_allow_regex", "disallow_allow_regex"):
+                for pat in role.get(key, []):
+                    try:
+                        re.compile(pat)
+                    except re.error as exc:
+                        raise SchemaError(
+                            f"roles[{role_name!r}].{key} invalid regex {pat!r}: {exc}"
+                        ) from exc
+            req_hooks = role.get("required_hooks", [])
+            if not isinstance(req_hooks, list):
+                raise SchemaError(
+                    f"roles[{role_name!r}].required_hooks must be a list"
+                )
+            for i, hook in enumerate(req_hooks):
+                if not isinstance(hook, dict):
+                    raise SchemaError(
+                        f"roles[{role_name!r}].required_hooks[{i}] must be a dict"
+                    )
+                if "event" not in hook or not isinstance(hook["event"], str):
+                    raise SchemaError(
+                        f"roles[{role_name!r}].required_hooks[{i}].event must be a string"
+                    )
+            cw = role.get("closed_world")
+            if cw is not None and not isinstance(cw, bool):
+                raise SchemaError(
+                    f"roles[{role_name!r}].closed_world must be a bool"
+                )
+
+    wr = ext.get("worker_roles")
+    if wr is not None and not isinstance(wr, dict):
+        raise SchemaError(f"worker_roles must be a dict, got {type(wr).__name__}")
+
+
 def merge_schemas(
     framework_schema: dict | None,
     org_extension_schema: dict,
+    *,
+    validate: bool = True,
 ) -> dict:
     """Merge a framework schema with an org-extension schema.
 
@@ -54,11 +158,14 @@ def merge_schemas(
     deep-copied and lightly normalised so downstream code can rely on
     the standard keys being present.
 
-    The signature accepts the framework schema today so that consumers
-    pin the API now; in a later 0.x revision the framework may carry
-    recommended defaults (e.g. a default ``required_hook_scripts``
-    list) that this function would inject, without changing the caller.
+    Before normalisation, the org-extension is validated against the
+    framework's structural contract (see :func:`_validate_extension_structure`).
+    Pass ``validate=False`` to skip this check; defaults to True so a
+    typo in ``forbidden_allow_regex`` cannot silently disappear from
+    the merged schema. Raises :class:`SchemaError` on violation.
     """
+    if validate:
+        _validate_extension_structure(org_extension_schema)
     merged: dict[str, Any] = deepcopy(org_extension_schema)
     g = merged.setdefault("global", {})
     g.setdefault("forbidden_allow_exact", [])
@@ -73,4 +180,5 @@ __all__ = [
     "load_framework_schema",
     "framework_schema_path",
     "merge_schemas",
+    "SchemaError",
 ]

--- a/src/core_harness/schema/__init__.py
+++ b/src/core_harness/schema/__init__.py
@@ -1,8 +1,76 @@
 """Framework schema (Layer 1 SOT).
 
-Will host the generic type definitions for permission/hook schema entries
-(e.g. ``forbidden_allow_*``, ``required_hook_scripts``). 0.0.1 is a
-placeholder; concrete types land in 0.1+.
+Hosts the generic type definitions (as a JSON Schema) for the per-role
+permission/hook configuration. Concrete entries — role names, named
+required_allow lists, ban regexes, ``workers_dir`` conventions, named
+worker_role templates — are NOT defined here. They live in the
+consumer's *org_extension_schema*.
+
+Public surface (0.1):
+
+* :func:`load_framework_schema` — return the framework JSON Schema dict.
+* :func:`framework_schema_path` — locate the on-disk JSON file.
+* :func:`merge_schemas`         — combine framework + org-extension into a
+  single dict the validator/generator can consume.
+
+See PR #196 §3 for the framework / org-extension split, and
+``framework_schema.json`` for the structural contract.
 """
 
-__all__: list[str] = []
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+_FRAMEWORK_SCHEMA_PATH = Path(__file__).resolve().parent / "framework_schema.json"
+
+
+def load_framework_schema() -> dict:
+    """Return the framework JSON Schema as a dict.
+
+    The returned dict is a fresh deep copy; mutating it does not affect
+    the package-level resource.
+    """
+    with _FRAMEWORK_SCHEMA_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def framework_schema_path() -> Path:
+    """Return the on-disk path to the framework schema JSON file."""
+    return _FRAMEWORK_SCHEMA_PATH
+
+
+def merge_schemas(
+    framework_schema: dict | None,
+    org_extension_schema: dict,
+) -> dict:
+    """Merge a framework schema with an org-extension schema.
+
+    The framework schema is currently a JSON Schema (meta-schema) that
+    constrains *shape only*; it does not contribute concrete data
+    entries. The merge result is therefore the org-extension dict,
+    deep-copied and lightly normalised so downstream code can rely on
+    the standard keys being present.
+
+    The signature accepts the framework schema today so that consumers
+    pin the API now; in a later 0.x revision the framework may carry
+    recommended defaults (e.g. a default ``required_hook_scripts``
+    list) that this function would inject, without changing the caller.
+    """
+    merged: dict[str, Any] = deepcopy(org_extension_schema)
+    g = merged.setdefault("global", {})
+    g.setdefault("forbidden_allow_exact", [])
+    g.setdefault("forbidden_allow_regex", [])
+    merged.setdefault("required_hook_scripts", [])
+    merged.setdefault("roles", {})
+    merged.setdefault("worker_roles", {})
+    return merged
+
+
+__all__ = [
+    "load_framework_schema",
+    "framework_schema_path",
+    "merge_schemas",
+]

--- a/src/core_harness/schema/framework_schema.json
+++ b/src/core_harness/schema/framework_schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/suisya-systems/core-harness/schema/framework_schema.json",
+  "title": "core-harness framework schema (Layer 1 SOT, v0)",
+  "description": "Type-only definition for org-extension role/permission schemas. Concrete entries (role names, named required_allow lists, ban regexes, naming conventions) are NOT defined here. They live in the consumer's org_extension_schema. See PR #196 §3.",
+  "type": "object",
+  "properties": {
+    "version": { "type": "integer", "minimum": 1 },
+    "$framework_schema_ref": { "type": "string" },
+    "global": {
+      "type": "object",
+      "description": "Global cross-role audit constraints. Concrete patterns are org-specific; only the structure is framework.",
+      "properties": {
+        "forbidden_allow_exact": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "permissions.allow entries that must never appear (exact-string match)."
+        },
+        "forbidden_allow_regex": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "permissions.allow entries that must never match any of these regexes."
+        }
+      },
+      "additionalProperties": false
+    },
+    "required_hook_scripts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Hook script names that MUST be referenced by at least one role's required_hooks[].command_contains. Cross-checked by validate_schema_integrity()."
+    },
+    "roles": {
+      "type": "object",
+      "description": "Audit constraints per role. Role names are org-specific; this only defines the per-role entry shape.",
+      "additionalProperties": { "$ref": "#/definitions/role_audit_entry" }
+    },
+    "worker_roles": {
+      "type": "object",
+      "description": "Concrete worker settings.local.json templates emitted by the generator.",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string" },
+          { "$ref": "#/definitions/worker_role_template" }
+        ]
+      }
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "role_audit_entry": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "docs_section": { "type": ["string", "null"] },
+        "settings_paths": { "type": "array", "items": { "type": "string" } },
+        "closed_world": { "type": "boolean" },
+        "required_allow": { "type": "array", "items": { "type": "string" } },
+        "allowed_allow_regex": { "type": "array", "items": { "type": "string" } },
+        "required_deny": { "type": "array", "items": { "type": "string" } },
+        "required_hooks": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/required_hook_spec" }
+        },
+        "disallow_allow_regex": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "required_hook_spec": {
+      "type": "object",
+      "required": ["event"],
+      "properties": {
+        "event": { "type": "string" },
+        "matcher_contains": { "type": "string" },
+        "command_contains": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "worker_role_template": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "$comment": { "type": "string" },
+        "permissions": {
+          "type": "object",
+          "properties": {
+            "allow": { "type": "array", "items": { "type": "string" } },
+            "deny": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": true
+        },
+        "hooks": { "type": "object" },
+        "env": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/core_harness/validator/__init__.py
+++ b/src/core_harness/validator/__init__.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Iterator
 
-from core_harness.schema import merge_schemas
+from core_harness.schema import SchemaError, merge_schemas
 
 
 # ---------------------------------------------------------------------------
@@ -75,22 +75,49 @@ class ValidationResult:
 # ---------------------------------------------------------------------------
 
 
+def _safe_dict(v: Any) -> dict:
+    return v if isinstance(v, dict) else {}
+
+
+def _safe_list(v: Any) -> list:
+    return v if isinstance(v, list) else []
+
+
 def _get_allow(config: dict) -> list:
-    return ((config.get("permissions") or {}).get("allow")) or []
+    return _safe_list(_safe_dict(config.get("permissions")).get("allow"))
 
 
 def _get_deny(config: dict) -> list:
-    return ((config.get("permissions") or {}).get("deny")) or []
+    return _safe_list(_safe_dict(config.get("permissions")).get("deny"))
 
 
 def _iter_hooks(config: dict) -> Iterable:
-    hooks = config.get("hooks") or {}
+    hooks = _safe_dict(config.get("hooks"))
     for event, entries in hooks.items():
-        for entry in entries or []:
+        for entry in _safe_list(entries):
+            if not isinstance(entry, dict):
+                continue
             matcher = entry.get("matcher", "") or ""
-            for sub in entry.get("hooks") or []:
+            if not isinstance(matcher, str):
+                matcher = ""
+            for sub in _safe_list(entry.get("hooks")):
+                if not isinstance(sub, dict):
+                    continue
                 cmd = sub.get("command", "") or ""
+                if not isinstance(cmd, str):
+                    cmd = ""
                 yield event, matcher, cmd
+
+
+def _safe_compile(pattern: str) -> Any:
+    """Compile a regex; return None on failure so the caller can record a
+    Finding instead of letting ``re.error`` escape (Layer 1 must turn
+    every form of malformed input into a closed-form audit failure).
+    """
+    try:
+        return re.compile(pattern)
+    except re.error:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +146,16 @@ def validate_config(
     if config is None:
         findings.append(Finding(source_label, role_name, "ERROR", "config block missing"))
         return findings
+    if not isinstance(config, dict):
+        findings.append(
+            Finding(
+                source_label,
+                role_name,
+                "ERROR",
+                f"config must be a dict, got {type(config).__name__}",
+            )
+        )
+        return findings
     if "__parse_error__" in config:
         findings.append(
             Finding(
@@ -139,7 +176,17 @@ def validate_config(
                 Finding(source_label, role_name, "ERROR", f"forbidden wide allow entry: {entry!r}")
             )
     for pattern in global_schema.get("forbidden_allow_regex", []):
-        rgx = re.compile(pattern)
+        rgx = _safe_compile(pattern)
+        if rgx is None:
+            findings.append(
+                Finding(
+                    source_label,
+                    role_name,
+                    "ERROR",
+                    f"global.forbidden_allow_regex contains invalid regex /{pattern}/",
+                )
+            )
+            continue
         for entry in allow:
             if rgx.search(entry):
                 findings.append(
@@ -152,7 +199,17 @@ def validate_config(
                 )
 
     for pattern in role_schema.get("disallow_allow_regex", []):
-        rgx = re.compile(pattern)
+        rgx = _safe_compile(pattern)
+        if rgx is None:
+            findings.append(
+                Finding(
+                    source_label,
+                    role_name,
+                    "ERROR",
+                    f"disallow_allow_regex contains invalid regex /{pattern}/",
+                )
+            )
+            continue
         for entry in allow:
             if rgx.search(entry):
                 findings.append(
@@ -174,7 +231,20 @@ def validate_config(
 
     if role_schema.get("closed_world"):
         required_set = set(required_allow)
-        extra_patterns = [re.compile(p) for p in role_schema.get("allowed_allow_regex", [])]
+        extra_patterns = []
+        for raw in role_schema.get("allowed_allow_regex", []):
+            compiled = _safe_compile(raw)
+            if compiled is None:
+                findings.append(
+                    Finding(
+                        source_label,
+                        role_name,
+                        "ERROR",
+                        f"allowed_allow_regex contains invalid regex /{raw}/",
+                    )
+                )
+                continue
+            extra_patterns.append(compiled)
         override_set = extra_allowed or set()
         for entry in allow:
             if entry in required_set:
@@ -357,11 +427,17 @@ def matches_worker_template(
     its captured value must agree across all occurrences in one match
     attempt. When ``expected_worker_dir`` is supplied, the
     ``{worker_dir}`` capture must equal it (path-separator
-    normalised).
+    normalised). A capture whose value still contains a literal
+    ``{name}`` token is rejected — Layer 1 must not declare an
+    unsubstituted settings file as "matching" the template, since that
+    would silently disable hook commands.
     """
     bindings: dict = {}
     if not _match(config, template, bindings):
         return False
+    for captured in bindings.values():
+        if isinstance(captured, str) and _PLACEHOLDER_PATTERN.search(captured):
+            return False
     if expected_worker_dir is not None and "{worker_dir}" in bindings:
         if _norm_path(bindings["{worker_dir}"]) != _norm_path(expected_worker_dir):
             return False
@@ -461,8 +537,12 @@ def validate_settings(
 
     ``role`` selects which entry under ``roles{}`` to validate against.
     """
-    merged = merge_schemas(framework_schema, org_extension_schema)
     findings: list = []
+    try:
+        merged = merge_schemas(framework_schema, org_extension_schema)
+    except SchemaError as exc:
+        findings.append(Finding("schema", "<global>", "ERROR", str(exc)))
+        return ValidationResult(findings=findings)
     if check_integrity:
         findings.extend(validate_schema_integrity(merged))
     role_schema = merged["roles"].get(role)

--- a/src/core_harness/validator/__init__.py
+++ b/src/core_harness/validator/__init__.py
@@ -1,10 +1,494 @@
-"""Schema validator. 0.0.1 placeholder; implementation lands in 0.1+."""
+"""Schema validator (Layer 1 SOT).
 
-from typing import Any
+Generic engine for auditing a per-role ``settings.local.json`` payload
+against a merged framework + org-extension schema. The validator owns
+the *algorithm* (closed-world check, forbidden-allow match, hook-script
+integrity, placeholder-aware worker_role template match). The
+*concrete entries* — role names, named required_allow lists, ban
+regexes — are supplied by the caller via the org-extension schema.
+See PR #196 §3 / §6.2.
+
+Public surface (0.1):
+
+* :func:`validate_settings`        — top-level entry point.
+* :func:`validate_config`          — single role/config validation.
+* :func:`validate_schema_integrity`— required_hook_scripts cross-check.
+* :func:`extract_role_blocks`      — pull JSON code blocks from a docs
+  projection markdown.
+* :func:`check_worker_settings`    — drift-check
+  ``<base>/*/.claude/settings.local.json`` against worker_roles.
+* :class:`Finding`                 — structured result entry.
+* :class:`ValidationResult`        — list[Finding] + ``ok`` summary.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from core_harness.schema import merge_schemas
 
 
-def validate_schema(*args: Any, **kwargs: Any) -> None:
-    raise NotImplementedError("validate_schema is a 0.0.1 placeholder; lands in 0.1+")
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
 
 
-__all__ = ["validate_schema"]
+@dataclass
+class Finding:
+    """A single validator finding (error or warning)."""
+
+    source: str
+    role: str
+    severity: str
+    message: str
+
+    def format(self) -> str:
+        return f"[{self.severity}] {self.source} :: {self.role} :: {self.message}"
+
+
+@dataclass
+class ValidationResult:
+    """Aggregated validator output."""
+
+    findings: list = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(f.severity == "ERROR" for f in self.findings)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def __iter__(self) -> Iterator:
+        return iter(self.findings)
+
+    def __len__(self) -> int:
+        return len(self.findings)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_allow(config: dict) -> list:
+    return ((config.get("permissions") or {}).get("allow")) or []
+
+
+def _get_deny(config: dict) -> list:
+    return ((config.get("permissions") or {}).get("deny")) or []
+
+
+def _iter_hooks(config: dict) -> Iterable:
+    hooks = config.get("hooks") or {}
+    for event, entries in hooks.items():
+        for entry in entries or []:
+            matcher = entry.get("matcher", "") or ""
+            for sub in entry.get("hooks") or []:
+                cmd = sub.get("command", "") or ""
+                yield event, matcher, cmd
+
+
+# ---------------------------------------------------------------------------
+# Per-role validation
+# ---------------------------------------------------------------------------
+
+
+def validate_config(
+    source_label: str,
+    role_name: str,
+    config: dict | None,
+    role_schema: dict,
+    global_schema: dict,
+    *,
+    extra_allowed: set | None = None,
+) -> list:
+    """Validate a single role's ``config`` dict against ``role_schema``.
+
+    ``global_schema`` is the merged schema's ``global`` block (carrying
+    ``forbidden_allow_exact`` / ``forbidden_allow_regex``).
+    ``extra_allowed`` is the optional override-allow set drawn from a
+    sibling ``settings.local.override.json`` (closed-world escape
+    hatch).
+    """
+    findings: list = []
+    if config is None:
+        findings.append(Finding(source_label, role_name, "ERROR", "config block missing"))
+        return findings
+    if "__parse_error__" in config:
+        findings.append(
+            Finding(
+                source_label,
+                role_name,
+                "ERROR",
+                f"JSON parse error: {config['__parse_error__']}",
+            )
+        )
+        return findings
+
+    allow = _get_allow(config)
+    deny = _get_deny(config)
+
+    for entry in allow:
+        if entry in global_schema.get("forbidden_allow_exact", []):
+            findings.append(
+                Finding(source_label, role_name, "ERROR", f"forbidden wide allow entry: {entry!r}")
+            )
+    for pattern in global_schema.get("forbidden_allow_regex", []):
+        rgx = re.compile(pattern)
+        for entry in allow:
+            if rgx.search(entry):
+                findings.append(
+                    Finding(
+                        source_label,
+                        role_name,
+                        "ERROR",
+                        f"forbidden allow entry {entry!r} matches /{pattern}/",
+                    )
+                )
+
+    for pattern in role_schema.get("disallow_allow_regex", []):
+        rgx = re.compile(pattern)
+        for entry in allow:
+            if rgx.search(entry):
+                findings.append(
+                    Finding(
+                        source_label,
+                        role_name,
+                        "ERROR",
+                        f"role contract violation: {entry!r} matches /{pattern}/",
+                    )
+                )
+
+    allow_set = set(allow)
+    required_allow = role_schema.get("required_allow", [])
+    for req in required_allow:
+        if req not in allow_set:
+            findings.append(
+                Finding(source_label, role_name, "ERROR", f"missing required allow: {req!r}")
+            )
+
+    if role_schema.get("closed_world"):
+        required_set = set(required_allow)
+        extra_patterns = [re.compile(p) for p in role_schema.get("allowed_allow_regex", [])]
+        override_set = extra_allowed or set()
+        for entry in allow:
+            if entry in required_set:
+                continue
+            if entry in override_set:
+                continue
+            if any(p.search(entry) for p in extra_patterns):
+                continue
+            findings.append(
+                Finding(
+                    source_label,
+                    role_name,
+                    "ERROR",
+                    (
+                        f"unknown allow entry {entry!r} -- not in schema's "
+                        "required_allow nor allowed_allow_regex; add to schema "
+                        "(with justification) or remove."
+                    ),
+                )
+            )
+
+    deny_set = set(deny)
+    for req in role_schema.get("required_deny", []):
+        if req not in deny_set:
+            findings.append(
+                Finding(source_label, role_name, "ERROR", f"missing required deny: {req!r}")
+            )
+
+    hook_tuples = list(_iter_hooks(config))
+    for req in role_schema.get("required_hooks", []):
+        ev = req["event"]
+        match_sub = req.get("matcher_contains", "")
+        cmd_sub = req.get("command_contains", "")
+        hit = any(
+            event == ev and match_sub in matcher and cmd_sub in cmd
+            for event, matcher, cmd in hook_tuples
+        )
+        if not hit:
+            findings.append(
+                Finding(
+                    source_label,
+                    role_name,
+                    "ERROR",
+                    (
+                        "missing required hook: "
+                        f"event={ev} matcher~={match_sub!r} command~={cmd_sub!r}"
+                    ),
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def validate_schema_integrity(schema: dict) -> list:
+    """Cross-check ``required_hook_scripts`` against ``roles[*].required_hooks``.
+
+    Every entry in ``required_hook_scripts`` must be referenced by at
+    least one role's ``required_hooks[].command_contains`` (literal
+    substring); otherwise the schema declares a script as mandatory yet
+    no role enforces it.
+    """
+    findings: list = []
+    required_scripts = set(schema.get("required_hook_scripts", []))
+    seen: set = set()
+    for role_name, role in schema.get("roles", {}).items():
+        for hook in role.get("required_hooks", []):
+            cmd = hook.get("command_contains", "")
+            if cmd.endswith(".sh"):
+                seen.add(cmd)
+    missing = required_scripts - seen
+    for script in sorted(missing):
+        findings.append(
+            Finding(
+                "schema",
+                "<global>",
+                "ERROR",
+                f"required hook script {script!r} not referenced by any role",
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Docs projection
+# ---------------------------------------------------------------------------
+
+
+def extract_role_blocks(md_text: str, roles: dict) -> dict:
+    """Extract the first ```json code block under each role's docs heading.
+
+    The role schema's ``docs_section`` field must appear inside a
+    ``## ``-prefixed heading line for the role to match.
+    """
+    results: dict = {}
+    sections = re.split(r"(?m)^## ", md_text)
+    for role_name, role_def in roles.items():
+        marker = role_def.get("docs_section")
+        if not marker:
+            continue
+        block = None
+        for section in sections[1:]:
+            if marker in section.splitlines()[0]:
+                m = re.search(r"```json\n(.*?)\n```", section, re.DOTALL)
+                if m:
+                    try:
+                        block = json.loads(m.group(1))
+                    except json.JSONDecodeError as exc:
+                        block = {"__parse_error__": str(exc)}
+                break
+        results[role_name] = block
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Worker template match (drift detection)
+# ---------------------------------------------------------------------------
+
+
+_PLACEHOLDER_PATTERN = re.compile(r"\{[a-zA-Z_][a-zA-Z0-9_]*\}")
+
+
+def _strip_meta(template: dict) -> dict:
+    return {k: v for k, v in template.items() if k not in {"description", "$comment"}}
+
+
+def _norm_path(s: str) -> str:
+    return s.replace("\\", "/").rstrip("/")
+
+
+def _match(value: Any, template: Any, bindings: dict) -> bool:
+    if isinstance(template, str):
+        if not isinstance(value, str):
+            return False
+        if not _PLACEHOLDER_PATTERN.search(template):
+            return value == template
+        parts = re.split(r"(\{[a-zA-Z_][a-zA-Z0-9_]*\})", template)
+        pattern = "".join(
+            f"(?P<__ph{idx}>.*)" if _PLACEHOLDER_PATTERN.fullmatch(p) else re.escape(p)
+            for idx, p in enumerate(parts)
+        )
+        m = re.fullmatch(pattern, value)
+        if m is None:
+            return False
+        ph_indices = [i for i, p in enumerate(parts) if _PLACEHOLDER_PATTERN.fullmatch(p)]
+        for idx in ph_indices:
+            ph = parts[idx]
+            captured = m.group(f"__ph{idx}")
+            existing = bindings.get(ph)
+            if existing is None:
+                bindings[ph] = captured
+            elif existing != captured:
+                return False
+        return True
+    if isinstance(template, list):
+        if not isinstance(value, list) or len(value) != len(template):
+            return False
+        return all(_match(v, t, bindings) for v, t in zip(value, template))
+    if isinstance(template, dict):
+        if not isinstance(value, dict) or set(value) != set(template):
+            return False
+        return all(_match(value[k], template[k], bindings) for k in template)
+    return value == template
+
+
+def matches_worker_template(
+    config: dict,
+    template: dict,
+    *,
+    expected_worker_dir: str | None = None,
+) -> bool:
+    """Return True when ``config`` is a placeholder-consistent match of
+    ``template``.
+
+    Each placeholder ({worker_dir}, {consumer_root}, …) is captured;
+    its captured value must agree across all occurrences in one match
+    attempt. When ``expected_worker_dir`` is supplied, the
+    ``{worker_dir}`` capture must equal it (path-separator
+    normalised).
+    """
+    bindings: dict = {}
+    if not _match(config, template, bindings):
+        return False
+    if expected_worker_dir is not None and "{worker_dir}" in bindings:
+        if _norm_path(bindings["{worker_dir}"]) != _norm_path(expected_worker_dir):
+            return False
+    return True
+
+
+def check_worker_settings(schema: dict, base_dir) -> list:
+    """Walk ``<base_dir>/*/.claude/settings.local.json`` and report
+    drift against the ``worker_roles`` templates from ``schema``."""
+    findings: list = []
+    base_dir = Path(base_dir)
+    if not base_dir.is_dir():
+        findings.append(
+            Finding(
+                str(base_dir),
+                "<worker-settings>",
+                "ERROR",
+                "base directory does not exist",
+            )
+        )
+        return findings
+
+    worker_roles_raw = schema.get("worker_roles") or {}
+    templates = {
+        name: _strip_meta(body)
+        for name, body in worker_roles_raw.items()
+        if not name.startswith("$") and isinstance(body, dict)
+    }
+    if not templates:
+        findings.append(
+            Finding("schema", "<worker-settings>", "ERROR", "schema has no worker_roles templates")
+        )
+        return findings
+
+    for worker_dir in sorted(p for p in base_dir.iterdir() if p.is_dir()):
+        settings_path = worker_dir / ".claude" / "settings.local.json"
+        if not settings_path.is_file():
+            continue
+        try:
+            config = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            findings.append(
+                Finding(
+                    str(settings_path),
+                    "<worker-settings>",
+                    "ERROR",
+                    f"JSON parse error: {exc}",
+                )
+            )
+            continue
+        expected_wd = str(worker_dir.resolve())
+        matched = [
+            name
+            for name, tmpl in templates.items()
+            if matches_worker_template(config, tmpl, expected_worker_dir=expected_wd)
+        ]
+        if not matched:
+            findings.append(
+                Finding(
+                    str(settings_path),
+                    "<worker-settings>",
+                    "ERROR",
+                    (
+                        "does not match any worker_roles template; "
+                        "regenerate via the generator or extend the schema"
+                    ),
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def validate_settings(
+    settings_local_json: dict | None,
+    framework_schema: dict | None,
+    org_extension_schema: dict,
+    *,
+    role: str,
+    source_label: str = "<settings>",
+    extra_allowed: set | None = None,
+    check_integrity: bool = True,
+) -> ValidationResult:
+    """Validate one ``settings.local.json`` payload for ``role``.
+
+    ``framework_schema`` is the dict returned by
+    :func:`core_harness.schema.load_framework_schema`. It contributes
+    structure today and may contribute defaults in future 0.x
+    revisions; pass ``None`` to skip merge-time injection.
+
+    ``org_extension_schema`` carries the concrete role definitions and
+    audit constraints (the consumer's renamed
+    ``role_configs_schema.json``).
+
+    ``role`` selects which entry under ``roles{}`` to validate against.
+    """
+    merged = merge_schemas(framework_schema, org_extension_schema)
+    findings: list = []
+    if check_integrity:
+        findings.extend(validate_schema_integrity(merged))
+    role_schema = merged["roles"].get(role)
+    if role_schema is None:
+        findings.append(Finding(source_label, role, "ERROR", f"unknown role: {role!r}"))
+        return ValidationResult(findings=findings)
+    findings.extend(
+        validate_config(
+            source_label,
+            role,
+            settings_local_json,
+            role_schema,
+            merged.get("global", {}),
+            extra_allowed=extra_allowed,
+        )
+    )
+    return ValidationResult(findings=findings)
+
+
+__all__ = [
+    "Finding",
+    "ValidationResult",
+    "validate_settings",
+    "validate_config",
+    "validate_schema_integrity",
+    "extract_role_blocks",
+    "check_worker_settings",
+    "matches_worker_template",
+]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,147 @@
+"""Generic generator tests.
+
+Synthetic worker_roles fixtures only — no consumer-org template names
+or paths. The generator must emit valid output for any caller-supplied
+placeholder mapping. Org-specific template behaviour (e.g. ja's
+``doc-audit`` denies Edit/Write) lives in the consumer repository.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from core_harness.generator import generate_settings, render_role
+from core_harness.schema import load_framework_schema
+
+
+def _fixture_schema() -> dict:
+    return {
+        "version": 1,
+        "worker_roles": {
+            "$comment": "test fixture",
+            "default": {
+                "description": "test default",
+                "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash \"{consumer_root}/hooks/example.sh\"",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "env": {
+                    "WORKER_DIR": "{worker_dir}",
+                    "CONSUMER_ROOT": "{consumer_root}",
+                },
+            },
+            "with-extra": {
+                "description": "uses an extra placeholder",
+                "permissions": {"allow": [], "deny": []},
+                "env": {"EXTRA": "{my_alias}"},
+            },
+        },
+    }
+
+
+class RenderRoleTests(unittest.TestCase):
+    def test_substitutes_placeholders(self):
+        out = render_role(
+            _fixture_schema(),
+            "default",
+            worker_dir="/abs/wd",
+            consumer_root="/abs/co",
+        )
+        self.assertEqual(out["env"]["WORKER_DIR"], "/abs/wd")
+        self.assertEqual(out["env"]["CONSUMER_ROOT"], "/abs/co")
+        cmd = out["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        self.assertIn("/abs/co/hooks/example.sh", cmd)
+        self.assertNotIn("{consumer_root}", cmd)
+
+    def test_strips_meta_keys(self):
+        out = render_role(
+            _fixture_schema(),
+            "default",
+            worker_dir="/wd",
+            consumer_root="/co",
+        )
+        self.assertNotIn("description", out)
+        self.assertNotIn("$comment", out)
+
+    def test_unknown_role_raises(self):
+        with self.assertRaises(KeyError) as ctx:
+            render_role(_fixture_schema(), "no-such-role", worker_dir="/x")
+        self.assertIn("unknown worker role", str(ctx.exception))
+
+    def test_dollar_prefixed_role_rejected(self):
+        with self.assertRaises(KeyError):
+            render_role(_fixture_schema(), "$comment", worker_dir="/x")
+
+    def test_extra_placeholder_substituted(self):
+        out = render_role(
+            _fixture_schema(),
+            "with-extra",
+            worker_dir="/wd",
+            my_alias="banana",
+        )
+        self.assertEqual(out["env"]["EXTRA"], "banana")
+
+    def test_input_schema_not_mutated(self):
+        schema = _fixture_schema()
+        before = schema["worker_roles"]["default"]["env"]["WORKER_DIR"]
+        render_role(schema, "default", worker_dir="/wd", consumer_root="/co")
+        self.assertEqual(
+            schema["worker_roles"]["default"]["env"]["WORKER_DIR"], before
+        )
+
+
+class GenerateSettingsTests(unittest.TestCase):
+    def test_top_level_entry_point(self):
+        out = generate_settings(
+            "default",
+            "/abs/wd",
+            load_framework_schema(),
+            _fixture_schema(),
+            consumer_root="/abs/co",
+        )
+        self.assertEqual(out["env"]["WORKER_DIR"], "/abs/wd")
+        self.assertEqual(out["env"]["CONSUMER_ROOT"], "/abs/co")
+
+    def test_extra_placeholders_supported(self):
+        out = generate_settings(
+            "with-extra",
+            "/abs/wd",
+            None,
+            _fixture_schema(),
+            extra_placeholders={"my_alias": "x"},
+        )
+        self.assertEqual(out["env"]["EXTRA"], "x")
+
+    def test_consumer_root_alias_pattern(self):
+        """A consumer org may keep a legacy placeholder alias by passing it
+        through ``extra_placeholders`` pointing at the same value as
+        ``consumer_root``."""
+        schema = _fixture_schema()
+        schema["worker_roles"]["aliased"] = {
+            "permissions": {"allow": [], "deny": []},
+            "env": {"OLD": "{old_root}", "NEW": "{consumer_root}"},
+        }
+        out = generate_settings(
+            "aliased",
+            "/wd",
+            None,
+            schema,
+            consumer_root="/co",
+            extra_placeholders={"old_root": "/co"},
+        )
+        self.assertEqual(out["env"]["OLD"], "/co")
+        self.assertEqual(out["env"]["NEW"], "/co")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import unittest
 
-from core_harness.generator import generate_settings, render_role
+from core_harness.generator import (
+    UnresolvedPlaceholderError,
+    generate_settings,
+    render_role,
+)
 from core_harness.schema import load_framework_schema
 
 
@@ -141,6 +145,28 @@ class GenerateSettingsTests(unittest.TestCase):
         )
         self.assertEqual(out["env"]["OLD"], "/co")
         self.assertEqual(out["env"]["NEW"], "/co")
+
+
+class FailClosedTests(unittest.TestCase):
+    def test_render_role_raises_on_unresolved_placeholder(self):
+        with self.assertRaises(UnresolvedPlaceholderError) as ctx:
+            render_role(
+                _fixture_schema(),
+                "default",
+                worker_dir="/abs/wd",
+                # consumer_root deliberately omitted
+            )
+        self.assertIn("consumer_root", str(ctx.exception))
+
+    def test_generate_settings_raises_on_missing_consumer_root(self):
+        with self.assertRaises(UnresolvedPlaceholderError):
+            generate_settings(
+                "default",
+                "/abs/wd",
+                None,
+                _fixture_schema(),
+                # consumer_root missing — fail closed
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -14,6 +14,7 @@ import unittest
 from pathlib import Path
 
 from core_harness.schema import (
+    SchemaError,
     framework_schema_path,
     load_framework_schema,
     merge_schemas,
@@ -346,6 +347,66 @@ class FindingTests(unittest.TestCase):
     def test_format(self):
         f = Finding("src", "role", "ERROR", "boom")
         self.assertEqual(f.format(), "[ERROR] src :: role :: boom")
+
+
+class FailClosedTests(unittest.TestCase):
+    """Layer 1 must turn malformed input into errors, not exceptions."""
+
+    def test_merge_rejects_non_list_forbidden_regex(self):
+        ext = {"global": {"forbidden_allow_regex": "not a list"}}
+        with self.assertRaises(SchemaError):
+            merge_schemas(None, ext)
+
+    def test_merge_rejects_invalid_regex(self):
+        ext = {"global": {"forbidden_allow_regex": ["["]}}
+        with self.assertRaises(SchemaError):
+            merge_schemas(None, ext)
+
+    def test_merge_rejects_non_dict_role(self):
+        ext = {"roles": {"alpha": "not a dict"}}
+        with self.assertRaises(SchemaError):
+            merge_schemas(None, ext)
+
+    def test_merge_rejects_non_string_required_hook_script(self):
+        ext = {"required_hook_scripts": [123]}
+        with self.assertRaises(SchemaError):
+            merge_schemas(None, ext)
+
+    def test_validate_settings_surfaces_schema_error(self):
+        bad_ext = {"global": {"forbidden_allow_regex": ["["]}}
+        result = validate_settings(
+            {"permissions": {"allow": []}},
+            None,
+            bad_ext,
+            role="alpha",
+        )
+        self.assertFalse(result.ok)
+        self.assertTrue(any("invalid regex" in f.message for f in result))
+
+    def test_validate_config_handles_non_dict_config(self):
+        merged = merge_schemas(None, _minimal_extension_schema())
+        findings = validate_config(
+            "test", "alpha", "i am not a dict", merged["roles"]["alpha"], merged["global"]
+        )
+        self.assertTrue(any("must be a dict" in f.message for f in findings))
+
+    def test_validate_config_handles_malformed_hooks(self):
+        merged = merge_schemas(None, _minimal_extension_schema())
+        # hooks entry is a string instead of a list of dicts
+        config = {
+            "permissions": {"allow": ["Bash(echo:*)"], "deny": ["Bash(rm -rf *)"]},
+            "hooks": "garbage",
+        }
+        findings = validate_config(
+            "test", "beta", config, merged["roles"]["beta"], merged["global"]
+        )
+        # missing required hook is detected; engine does not crash
+        self.assertTrue(any("missing required hook" in f.message for f in findings))
+
+    def test_matches_worker_template_rejects_unsubstituted_capture(self):
+        template = {"env": {"X": "{consumer_root}"}}
+        leaky_config = {"env": {"X": "{consumer_root}"}}  # placeholder leaked
+        self.assertFalse(matches_worker_template(leaky_config, template))
 
 
 if __name__ == "__main__":

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,352 @@
+"""Generic validator tests.
+
+Synthetic schema fixtures only — no consumer-org strings (no role names
+like 'secretary', no banned regexes specific to a particular org). The
+validator engine must be exercisable without claude-org-ja being on
+disk. Cross-fixture / consumer-doctrine tests live in the consumer
+repository.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from core_harness.schema import (
+    framework_schema_path,
+    load_framework_schema,
+    merge_schemas,
+)
+from core_harness.validator import (
+    Finding,
+    ValidationResult,
+    check_worker_settings,
+    extract_role_blocks,
+    matches_worker_template,
+    validate_config,
+    validate_schema_integrity,
+    validate_settings,
+)
+
+
+def _minimal_extension_schema() -> dict:
+    """A tiny, fully-synthetic org-extension schema."""
+    return {
+        "version": 1,
+        "global": {
+            "forbidden_allow_exact": ["Bash(* unsafe)"],
+            "forbidden_allow_regex": ["^mcp__legacy__"],
+        },
+        "required_hook_scripts": ["block-example.sh"],
+        "roles": {
+            "alpha": {
+                "docs_section": "Alpha",
+                "settings_paths": [],
+                "closed_world": True,
+                "required_allow": ["Bash(echo:*)"],
+                "allowed_allow_regex": [r"^Bash\(printf [a-z]+:\*\)$"],
+                "required_deny": [],
+                "required_hooks": [],
+                "disallow_allow_regex": [r"^Bash\(\*\)$"],
+            },
+            "beta": {
+                "docs_section": "Beta",
+                "settings_paths": [],
+                "closed_world": False,
+                "required_allow": ["Bash(echo:*)"],
+                "allowed_allow_regex": [],
+                "required_deny": ["Bash(rm -rf *)"],
+                "required_hooks": [
+                    {
+                        "event": "PreToolUse",
+                        "matcher_contains": "Bash",
+                        "command_contains": "block-example.sh",
+                    }
+                ],
+                "disallow_allow_regex": [],
+            },
+        },
+    }
+
+
+def _good_alpha() -> dict:
+    return {"permissions": {"allow": ["Bash(echo:*)"]}}
+
+
+def _good_beta() -> dict:
+    return {
+        "permissions": {
+            "allow": ["Bash(echo:*)"],
+            "deny": ["Bash(rm -rf *)"],
+        },
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "bash hooks/block-example.sh"}
+                    ],
+                }
+            ]
+        },
+    }
+
+
+class FrameworkSchemaTests(unittest.TestCase):
+    def test_load_framework_schema_returns_dict(self):
+        fw = load_framework_schema()
+        self.assertIsInstance(fw, dict)
+        self.assertIn("$schema", fw)
+        self.assertIn("definitions", fw)
+
+    def test_framework_schema_path_exists(self):
+        self.assertTrue(framework_schema_path().is_file())
+
+    def test_framework_schema_does_not_carry_org_specifics(self):
+        """Layer 1 purity: no role names / consumer regexes baked in."""
+        text = framework_schema_path().read_text(encoding="utf-8")
+        for forbidden in ("secretary", "dispatcher", "claude-peers", "workers_dir"):
+            self.assertNotIn(
+                forbidden,
+                text,
+                f"framework_schema.json must not mention {forbidden!r}",
+            )
+
+
+class MergeSchemasTests(unittest.TestCase):
+    def test_merge_normalises_missing_keys(self):
+        merged = merge_schemas(None, {})
+        self.assertEqual(merged["global"]["forbidden_allow_exact"], [])
+        self.assertEqual(merged["global"]["forbidden_allow_regex"], [])
+        self.assertEqual(merged["required_hook_scripts"], [])
+        self.assertEqual(merged["roles"], {})
+        self.assertEqual(merged["worker_roles"], {})
+
+    def test_merge_does_not_mutate_input(self):
+        ext = {"roles": {"x": {}}}
+        merge_schemas(None, ext)
+        self.assertNotIn("global", ext)
+
+
+class ValidateConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.schema = _minimal_extension_schema()
+
+    def _validate(self, role: str, config) -> list:
+        merged = merge_schemas(load_framework_schema(), self.schema)
+        return validate_config(
+            "test", role, config, merged["roles"][role], merged.get("global", {})
+        )
+
+    def test_good_alpha_passes(self):
+        self.assertEqual(self._validate("alpha", _good_alpha()), [])
+
+    def test_good_beta_passes(self):
+        self.assertEqual(self._validate("beta", _good_beta()), [])
+
+    def test_missing_config_errors(self):
+        findings = self._validate("alpha", None)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("missing", findings[0].message)
+
+    def test_forbidden_regex_match(self):
+        config = _good_alpha()
+        config["permissions"]["allow"].append("mcp__legacy__send")
+        findings = self._validate("alpha", config)
+        self.assertTrue(any("legacy" in f.message for f in findings))
+
+    def test_forbidden_exact_match(self):
+        config = _good_alpha()
+        config["permissions"]["allow"].append("Bash(* unsafe)")
+        findings = self._validate("alpha", config)
+        self.assertTrue(any("forbidden wide allow" in f.message for f in findings))
+
+    def test_role_contract_disallow_regex(self):
+        config = _good_alpha()
+        config["permissions"]["allow"].append("Bash(*)")
+        findings = self._validate("alpha", config)
+        self.assertTrue(any("role contract" in f.message for f in findings))
+
+    def test_missing_required_allow(self):
+        findings = self._validate("alpha", {"permissions": {"allow": []}})
+        self.assertTrue(any("missing required allow" in f.message for f in findings))
+
+    def test_beta_missing_required_deny(self):
+        config = _good_beta()
+        config["permissions"]["deny"] = []
+        findings = self._validate("beta", config)
+        self.assertTrue(any("missing required deny" in f.message for f in findings))
+
+    def test_beta_missing_required_hook(self):
+        config = _good_beta()
+        config["hooks"] = {}
+        findings = self._validate("beta", config)
+        self.assertTrue(any("missing required hook" in f.message for f in findings))
+
+    def test_closed_world_flags_unknown(self):
+        config = {"permissions": {"allow": ["Bash(echo:*)", "Bash(rogue:*)"]}}
+        findings = self._validate("alpha", config)
+        self.assertTrue(
+            any("unknown allow entry" in f.message and "rogue" in f.message for f in findings)
+        )
+
+    def test_closed_world_pattern_passes(self):
+        config = {"permissions": {"allow": ["Bash(echo:*)", "Bash(printf hi:*)"]}}
+        self.assertEqual(self._validate("alpha", config), [])
+
+    def test_open_world_ignores_extras(self):
+        config = _good_beta()
+        config["permissions"]["allow"].append("Bash(brand-new:*)")
+        self.assertEqual(self._validate("beta", config), [])
+
+    def test_extra_allowed_overrides_closed_world(self):
+        merged = merge_schemas(load_framework_schema(), self.schema)
+        config = {"permissions": {"allow": ["Bash(echo:*)", "Bash(escape:*)"]}}
+        findings = validate_config(
+            "test",
+            "alpha",
+            config,
+            merged["roles"]["alpha"],
+            merged["global"],
+            extra_allowed={"Bash(escape:*)"},
+        )
+        self.assertEqual(findings, [])
+
+
+class SchemaIntegrityTests(unittest.TestCase):
+    def test_unreferenced_required_script_errors(self):
+        schema = _minimal_extension_schema()
+        schema["required_hook_scripts"].append("nonexistent.sh")
+        findings = validate_schema_integrity(schema)
+        self.assertTrue(any("nonexistent.sh" in f.message for f in findings))
+
+    def test_referenced_required_script_passes(self):
+        schema = _minimal_extension_schema()
+        # beta references block-example.sh; integrity should pass
+        findings = validate_schema_integrity(schema)
+        self.assertEqual(findings, [])
+
+
+class ExtractRoleBlocksTests(unittest.TestCase):
+    def test_extracts_first_json_per_section(self):
+        md = (
+            "# Heading\n\n"
+            "## Alpha note\n\n"
+            "intro\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"a\"]}}\n```\n\n"
+            "## Beta\n\n"
+            "```json\n{\"permissions\": {\"allow\": [\"b\"]}}\n```\n"
+        )
+        blocks = extract_role_blocks(md, _minimal_extension_schema()["roles"])
+        self.assertEqual(blocks["alpha"]["permissions"]["allow"], ["a"])
+        self.assertEqual(blocks["beta"]["permissions"]["allow"], ["b"])
+
+    def test_invalid_json_surfaces_parse_error(self):
+        md = "## Alpha\n\n```json\n{not json}\n```\n"
+        blocks = extract_role_blocks(md, _minimal_extension_schema()["roles"])
+        self.assertIn("__parse_error__", blocks["alpha"])
+
+
+class WorkerTemplateMatchTests(unittest.TestCase):
+    TEMPLATE = {
+        "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "bash \"{consumer_root}/hooks/x.sh\"",
+                        }
+                    ],
+                }
+            ]
+        },
+        "env": {"WORKER_DIR": "{worker_dir}", "CONSUMER_ROOT": "{consumer_root}"},
+    }
+
+    def test_consistent_match(self):
+        config = {
+            "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {"type": "command", "command": 'bash "/abs/co/hooks/x.sh"'}
+                        ],
+                    }
+                ]
+            },
+            "env": {"WORKER_DIR": "/abs/wd", "CONSUMER_ROOT": "/abs/co"},
+        }
+        self.assertTrue(matches_worker_template(config, self.TEMPLATE))
+        self.assertTrue(
+            matches_worker_template(config, self.TEMPLATE, expected_worker_dir="/abs/wd")
+        )
+
+    def test_inconsistent_placeholder_rejected(self):
+        config = {
+            "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {"type": "command", "command": 'bash "/abs/co/hooks/x.sh"'}
+                        ],
+                    }
+                ]
+            },
+            "env": {"WORKER_DIR": "/abs/wd", "CONSUMER_ROOT": "/different/co"},
+        }
+        self.assertFalse(matches_worker_template(config, self.TEMPLATE))
+
+    def test_check_worker_settings_missing_base_dir(self):
+        findings = check_worker_settings({"worker_roles": {"x": self.TEMPLATE}}, Path("/no/such/__nope__"))
+        self.assertTrue(any("does not exist" in f.message for f in findings))
+
+
+class ValidateSettingsTopLevelTests(unittest.TestCase):
+    def test_validate_settings_returns_validation_result(self):
+        result = validate_settings(
+            _good_beta(),
+            load_framework_schema(),
+            _minimal_extension_schema(),
+            role="beta",
+        )
+        self.assertIsInstance(result, ValidationResult)
+        self.assertTrue(result.ok)
+
+    def test_validate_settings_unknown_role(self):
+        result = validate_settings(
+            _good_beta(),
+            load_framework_schema(),
+            _minimal_extension_schema(),
+            role="ghost",
+        )
+        self.assertFalse(result.ok)
+        self.assertTrue(any("unknown role" in f.message for f in result))
+
+    def test_validate_settings_surfaces_violations(self):
+        bad = _good_beta()
+        bad["permissions"]["deny"] = []
+        result = validate_settings(
+            bad,
+            load_framework_schema(),
+            _minimal_extension_schema(),
+            role="beta",
+        )
+        self.assertFalse(result.ok)
+
+
+class FindingTests(unittest.TestCase):
+    def test_format(self):
+        f = Finding("src", "role", "ERROR", "boom")
+        self.assertEqual(f.format(), "[ERROR] src :: role :: boom")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First substantive release of core-harness. Implements Phase 3 Step B per [claude-org-ja#196 design](https://github.com/suisya-systems/claude-org-ja/blob/main/docs/design/core-harness-extraction.md).

## Summary
- `core_harness.schema`: framework_schema.json (Layer 1 SOT, type-only JSON Schema), `load_framework_schema`, `framework_schema_path`, `merge_schemas` (with structural validation of org_extension)
- `core_harness.validator`: `validate_settings` + `validate_config` + `validate_schema_integrity` + `extract_role_blocks` + `check_worker_settings` + `matches_worker_template` + `Finding` / `ValidationResult`. Fail-closed on schema errors and unresolved-placeholder match attempts.
- `core_harness.generator`: `generate_settings` + `render_role` (org-neutral placeholders `{worker_dir}` / `{consumer_root}`; legacy `{claude_org_path}` via `extra_placeholders` alias). Raises `UnresolvedPlaceholderError` if any `{name}` token leaks into rendered output.
- `pyproject.toml` 0.0.1 → 0.1.0, classifier Pre-Alpha → Alpha, package-data ships `framework_schema.json`
- `CHANGELOG.md` [Unreleased] promoted to [0.1.0]
- `docs/api-surface-v0.x.md` updated; all 0.1 symbols listed as experimental

## Codex self-review (1 round, pre-merge)
1 Blocker + 2 Major + 1 Minor reported. Blocker / Major all fixed in commit 88bb95f:
- [Blocker] Unresolved-placeholder leak — generator now scans output for `{token}` and raises; validator's template-match treats unresolved tokens in captures as non-match (no silent match).
- [Major] `framework_schema.json` was unused (merge was setdefault-only) — `merge_schemas` now structurally validates org_extension (list-of-str / dict-roles / valid regex / `required_hooks.event` mandatory) and raises `SchemaError`. validator converts to `Finding` (fail-closed).
- [Major] Malformed hooks / invalid regex caused `AttributeError` / `re.error` escape — added `_safe_dict` / `_safe_list` / `_safe_compile` defenses; non-dict configs now produce `Finding` instead of crashing.

## Known limitation (Minor, deferred)
- Integrity check filters hook scripts by `.endswith(".sh")`. Other shell-style script extensions (`.bash`, `.zsh`) are not picked up. Acceptable for v0.1 since claude-org-ja exclusively uses `.sh`. Will revisit when a consumer needs broader coverage.

## Tests
48 passed (`python -m pytest tests/ -v`). 38 from initial commit + 10 new fail-closed tests.

## Layer 1 purity
No claude-org names, paths, or roles in this change. Org-specific entries (secretary 38 entries, name lists, `^mcp__claude-peers__` ban) remain in claude-org-ja and will be added via `merge_schemas(framework, org_extension)` in the ja shim PR.

## Next
After merge: tag `v0.1.0` so claude-org-ja can pin via `pip install git+https://github.com/suisya-systems/core-harness@v0.1.0` (Q10, design §7).

## Refs
- ja Issue: suisya-systems/claude-org-ja#128
- design: suisya-systems/claude-org-ja#196