### PR TITLE
feat: Step C — hook framework (HookRunner + bash lib, 0.2.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.toml text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,58 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-02
+
+### Added
+
+- `core_harness.hooks` (Step C — hook framework, refs ja#128 / design
+  PR #196 §4 Step C):
+  - `HookRunner` class (`parse_pretooluse_stdin`, `exit_with_block`,
+    `exit_ok`) — Python helper for the PreToolUse hook contract.
+  - Module-level convenience wrappers `parse_pretooluse_stdin()`,
+    `exit_with_block(message)`, `exit_ok()`.
+  - Constants `DEFAULT_BLOCK_PREFIX` (`"ブロック: "`, retained for
+    legacy consumer-test compatibility), `BLOCK_EXIT_CODE` (= 2),
+    `ALLOW_EXIT_CODE` (= 0).
+  - `lib_path()` returning the on-disk directory of the bash companion
+    library (path-configurable; consumers source it from there).
+  - `CORE_HARNESS_BLOCK_PREFIX` env var + `block_prefix=` constructor
+    argument so non-Japanese consumers can override the deny-line
+    prefix without forking.
+- `core_harness/hooks/lib/core_harness_hooks.sh` — bash companion
+  library with `block_with_message`, `require_dependency`,
+  `read_pretooluse_{command,file_path,tool_name}`, and the generic
+  command-string parsers (`split_segments`, `flatten_substitutions`,
+  `collect_assignments`, `expand_known_vars`, `unwrap_eval_and_bashc`)
+  formerly duplicated in the original consumer's
+  `.hooks/lib/segment-split.sh`.
+- `docs/hook-contract.md` — contract specification (stdin JSON shape,
+  exit code semantics, stderr block-prefix format, helper APIs).
+- `tests/test_hooks.py`, `tests/test_hooks_bash.sh` — generic-only
+  framework tests (no consumer-org strings).
+
+### Changed
+
+- `core_harness.hooks` graduated from placeholder to experimental.
+- `pyproject.toml`: `core_harness.hooks` now ships `lib/*.sh` as
+  package data so `lib_path()` resolves through `pip install` and
+  `git+https://...@vX` installs alike.
+
+### Notes
+
+- The default block-message prefix `"ブロック: "` exists solely for
+  back-compat with the original consumer's hook test suite during the
+  0.x transition. New consumers SHOULD set
+  `CORE_HARNESS_BLOCK_PREFIX`. The default may be retired no earlier
+  than 1.0 with a deprecation window; see `docs/hook-contract.md` §5.
+- Hook *script bodies* (block-no-verify, block-dangerous-git, etc.)
+  remain in the consumer repo for this release; only the wiring
+  framework / contract / generic parser library moves up. Movement of
+  generic hook scripts may follow in a later 0.x once the contract has
+  bedded in.
+- `core_harness.audit` remains a placeholder; Step D in a subsequent
+  0.x release.
+
 ## [0.1.0] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to pre-1.0 semantic versioning as defined in
     `exit_ok`) — Python helper for the PreToolUse hook contract.
   - Module-level convenience wrappers `parse_pretooluse_stdin()`,
     `exit_with_block(message)`, `exit_ok()`.
-  - Constants `DEFAULT_BLOCK_PREFIX` (`"ブロック: "`, retained for
-    legacy consumer-test compatibility), `BLOCK_EXIT_CODE` (= 2),
-    `ALLOW_EXIT_CODE` (= 0).
+  - Constants `DEFAULT_BLOCK_PREFIX` (`"Blocked: "`, neutral English —
+    Layer 1 ships no consumer-specific locale; consumers override),
+    `BLOCK_EXIT_CODE` (= 2), `ALLOW_EXIT_CODE` (= 0).
   - `lib_path()` returning the on-disk directory of the bash companion
     library (path-configurable; consumers source it from there).
   - `CORE_HARNESS_BLOCK_PREFIX` env var + `block_prefix=` constructor
@@ -47,11 +47,13 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ### Notes
 
-- The default block-message prefix `"ブロック: "` exists solely for
-  back-compat with the original consumer's hook test suite during the
-  0.x transition. New consumers SHOULD set
-  `CORE_HARNESS_BLOCK_PREFIX`. The default may be retired no earlier
-  than 1.0 with a deprecation window; see `docs/hook-contract.md` §5.
+- The default block-message prefix is the neutral English
+  `"Blocked: "`. Layer 1 deliberately does not bake any consumer
+  locale into the framework default (Q4 one-way dependency). The
+  original consumer (claude-org-ja) injects its legacy
+  `"ブロック: "` contract at the org boundary via
+  `CORE_HARNESS_BLOCK_PREFIX` / `HookRunner(block_prefix=...)`. See
+  `docs/hook-contract.md` §5.
 - Hook *script bodies* (block-no-verify, block-dangerous-git, etc.)
   remain in the consumer repo for this release; only the wiring
   framework / contract / generic parser library moves up. Movement of

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -1,21 +1,21 @@
 # Public API Surface — 0.x
 
-> **Status: 0.1.0 published.** This document tracks the evolving public
+> **Status: 0.2.0 published.** This document tracks the evolving public
 > surface during the pre-1.0 phase. Items below are *experimental*
 > unless explicitly marked `stable`; signatures may change between
 > minor versions per [`semver-policy.md`](semver-policy.md).
 
 ## Modules
 
-| Module | Status (0.1) | Notes |
+| Module | Status (0.2) | Notes |
 |---|---|---|
 | `core_harness.schema` | experimental | Framework JSON Schema + merge helper. Type-only — concrete role names / consumer regexes live in the org-extension schema (PR #196 §3). |
 | `core_harness.validator` | experimental | Audit engine for per-role `settings.local.json`. |
 | `core_harness.generator` | experimental | Worker `settings.local.json` template renderer. |
-| `core_harness.hooks` | placeholder | Hook framework lib (Step C). |
+| `core_harness.hooks` | experimental | PreToolUse hook contract (Step C, 0.2). Python helper + bash companion lib + `docs/hook-contract.md`. |
 | `core_harness.audit` | placeholder | Journal API (Step D). |
 
-## Public symbols (0.1)
+## Public symbols (0.2)
 
 ### `core_harness.schema`
 
@@ -53,6 +53,37 @@
 - Arbitrary names supplied via `extra_placeholders={...}` for legacy
   alias support (e.g. consumers may pass `{claude_org_path}` pointing
   at the same value as `consumer_root`).
+
+### `core_harness.hooks`
+
+| Symbol | Status | Purpose |
+|---|---|---|
+| `HookRunner(*, block_prefix=None, stderr=None, stdin=None)` | experimental | Helper for Python-implemented PreToolUse hooks. |
+| `HookRunner.parse_pretooluse_stdin() -> Mapping[str, Any]` | experimental | Read + JSON-decode hook payload from stdin. Empty stdin → `{}`; malformed JSON → block. |
+| `HookRunner.exit_with_block(message: str)` | experimental | Write `{prefix}{message}` to stderr, exit 2. |
+| `HookRunner.exit_ok()` | experimental | Exit 0. |
+| `parse_pretooluse_stdin()` | experimental | Module-level convenience for `HookRunner().parse_pretooluse_stdin()`. |
+| `exit_with_block(message)` | experimental | Module-level convenience for `HookRunner().exit_with_block(message)`. |
+| `exit_ok()` | experimental | Module-level convenience for `HookRunner().exit_ok()`. |
+| `lib_path() -> Path` | experimental | On-disk directory of the bash companion library (`core_harness_hooks.sh`). |
+| `DEFAULT_BLOCK_PREFIX` | experimental | Default deny-line prefix (`"ブロック: "`). |
+| `BLOCK_EXIT_CODE` | experimental | `2` — deny exit code. |
+| `ALLOW_EXIT_CODE` | experimental | `0` — allow exit code. |
+
+#### Bash companion (`core_harness_hooks.sh`)
+
+Sourced via the path returned by `lib_path()`. Public functions:
+`block_with_message`, `require_dependency`, `read_pretooluse_command`,
+`read_pretooluse_file_path`, `read_pretooluse_tool_name`,
+`split_segments`, `flatten_substitutions`, `collect_assignments`,
+`expand_known_vars`, `unwrap_eval_and_bashc`. See
+[`hook-contract.md`](hook-contract.md) for full spec.
+
+#### Environment variables
+
+- `CORE_HARNESS_BLOCK_PREFIX` — overrides the default `"ブロック: "`
+  prefix in both the Python helper and the bash companion. Set this
+  for non-Japanese consumers.
 
 ## 1.0 graduation conditions
 

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -66,7 +66,7 @@
 | `exit_with_block(message)` | experimental | Module-level convenience for `HookRunner().exit_with_block(message)`. |
 | `exit_ok()` | experimental | Module-level convenience for `HookRunner().exit_ok()`. |
 | `lib_path() -> Path` | experimental | On-disk directory of the bash companion library (`core_harness_hooks.sh`). |
-| `DEFAULT_BLOCK_PREFIX` | experimental | Default deny-line prefix (`"ブロック: "`). |
+| `DEFAULT_BLOCK_PREFIX` | experimental | Default deny-line prefix (`"Blocked: "`, neutral English; consumers override). |
 | `BLOCK_EXIT_CODE` | experimental | `2` — deny exit code. |
 | `ALLOW_EXIT_CODE` | experimental | `0` — allow exit code. |
 
@@ -81,9 +81,11 @@ Sourced via the path returned by `lib_path()`. Public functions:
 
 #### Environment variables
 
-- `CORE_HARNESS_BLOCK_PREFIX` — overrides the default `"ブロック: "`
-  prefix in both the Python helper and the bash companion. Set this
-  for non-Japanese consumers.
+- `CORE_HARNESS_BLOCK_PREFIX` — overrides the default `"Blocked: "`
+  prefix in both the Python helper and the bash companion. Consumers
+  with a locale-specific contract (e.g. claude-org-ja's
+  `"ブロック: "`) export this at their org boundary so Layer 1 stays
+  unaware of consumer locale.
 
 ## 1.0 graduation conditions
 

--- a/docs/hook-contract.md
+++ b/docs/hook-contract.md
@@ -41,12 +41,18 @@ The deny-reason line follows the format:
 {block_prefix}{reason}
 ```
 
-where `{block_prefix}` defaults to `"ブロック: "` (legacy compatibility
-with claude-org-ja's existing 380+ hook tests) and is overridable per
-process via the `CORE_HARNESS_BLOCK_PREFIX` environment variable, or
-per-call via `HookRunner(block_prefix=...)` in Python /
+where `{block_prefix}` defaults to the neutral English `"Blocked: "`.
+Layer 1 ships no consumer-specific locale string. Consumers that need a
+different prefix (for example claude-org-ja's legacy `"ブロック: "`
+contract used by 380+ existing hook tests) inject it per process via
+the `CORE_HARNESS_BLOCK_PREFIX` environment variable, or per-call via
+`HookRunner(block_prefix=...)` in Python /
 `CORE_HARNESS_BLOCK_PREFIX=...` exported before sourcing
 `core_harness_hooks.sh` in bash.
+
+Resolution order (Python and bash both): explicit constructor argument
+→ `CORE_HARNESS_BLOCK_PREFIX` env var → `DEFAULT_BLOCK_PREFIX`
+(`"Blocked: "`).
 
 Future minor versions may introduce a typed (JSON) stderr alternative
 behind a feature flag; the plain-text contract documented here remains
@@ -75,9 +81,10 @@ runner.exit_ok()
 - `exit_with_block(message)`: writes `{prefix}{message}\n` to stderr,
   flushes, exits 2. Never returns.
 - `exit_ok()`: exits 0. Never returns.
-- The block-message prefix defaults to `"ブロック: "` and is resolved in
-  this priority order: explicit constructor argument →
-  `CORE_HARNESS_BLOCK_PREFIX` env var → `DEFAULT_BLOCK_PREFIX`.
+- The block-message prefix defaults to `"Blocked: "` (neutral English)
+  and is resolved in this priority order: explicit constructor
+  argument → `CORE_HARNESS_BLOCK_PREFIX` env var →
+  `DEFAULT_BLOCK_PREFIX`.
 
 ## 3. Bash helper API
 
@@ -138,14 +145,22 @@ can call several without re-reading stdin.
 - Path-normalisation helpers tied to the consumer's directory layout —
   consumers ship those alongside their org-specific hooks.
 
-## 5. Backward compatibility
+## 5. Consumer-specific localisation
 
-The default block-message prefix `"ブロック: "` exists solely to keep the
-original consumer's existing hook test suite green during the 0.x
-transition. New consumers SHOULD set `CORE_HARNESS_BLOCK_PREFIX` to a
-value appropriate for their locale (e.g. `"BLOCKED: "`). The default
-may be retired no earlier than 1.0, with a deprecation warning at
-0.(N-1).
+Layer 1 (`core-harness`) ships only the neutral English default
+`"Blocked: "`. Consumers with a localised contract — for example
+claude-org-ja's legacy `"ブロック: "` deny-line, used by an existing
+380+ hook test suite — inject their prefix at the org boundary, never
+inside `core-harness`:
+
+- **Python** consumers: instantiate `HookRunner(block_prefix="ブロック: ")`,
+  or set `CORE_HARNESS_BLOCK_PREFIX` once at process start.
+- **Bash** consumers: `export CORE_HARNESS_BLOCK_PREFIX="ブロック: "`
+  before sourcing `core_harness_hooks.sh`.
+
+This keeps the dependency one-way: `core-harness` does not know about
+any consumer's locale, and adding a new consumer with a different
+locale does not require a `core-harness` release.
 
 ## 6. Open questions tracked for 1.0
 

--- a/docs/hook-contract.md
+++ b/docs/hook-contract.md
@@ -1,0 +1,155 @@
+# PreToolUse Hook Contract
+
+> Status: experimental (0.2). Subject to change per
+> [`semver-policy.md`](semver-policy.md) until 1.0.
+
+`core-harness` defines a minimal, language-neutral wire contract for
+[Claude Code PreToolUse hooks](https://docs.claude.com/en/docs/claude-code/hooks).
+Consumer-org-specific deny logic plugs into this contract from either
+Python or bash without depending on each other.
+
+## 1. Wire format
+
+### 1.1 Input — stdin
+
+Claude Code delivers a single JSON object on stdin per hook invocation.
+Hooks MAY ignore fields they do not need. The fields the framework
+acknowledges are:
+
+| Field | Type | Tools | Notes |
+|---|---|---|---|
+| `tool_name` | string | all | One of `Bash`, `Edit`, `Write`, `NotebookEdit`, etc. |
+| `tool_input.command` | string | `Bash` | The shell command string Claude is about to run. |
+| `tool_input.file_path` | string | `Edit`/`Write`/`NotebookEdit` | Target file path (caller-provided; not yet normalized). |
+
+Hooks MUST tolerate empty / absent fields by treating them as "out of
+scope" (exit 0). Hooks MUST NOT trust the field set to be exhaustive —
+new fields may be added by upstream tooling between minor versions of
+Claude Code.
+
+### 1.2 Output — exit code + stderr
+
+| Exit code | Meaning | stderr |
+|---|---|---|
+| `0` | Allow. The tool call proceeds. | Ignored. |
+| `2` | Deny. The tool call is blocked. | The first line is shown to the user as the deny reason. |
+| `1` (or any non-zero ≠ 2) | Hook crashed. Treated as deny by Claude Code, but the message format is undefined. Hooks SHOULD avoid this path. |
+
+The deny-reason line follows the format:
+
+```
+{block_prefix}{reason}
+```
+
+where `{block_prefix}` defaults to `"ブロック: "` (legacy compatibility
+with claude-org-ja's existing 380+ hook tests) and is overridable per
+process via the `CORE_HARNESS_BLOCK_PREFIX` environment variable, or
+per-call via `HookRunner(block_prefix=...)` in Python /
+`CORE_HARNESS_BLOCK_PREFIX=...` exported before sourcing
+`core_harness_hooks.sh` in bash.
+
+Future minor versions may introduce a typed (JSON) stderr alternative
+behind a feature flag; the plain-text contract documented here remains
+the default for the 0.x line.
+
+## 2. Python helper API
+
+```python
+from core_harness.hooks import HookRunner, exit_with_block, exit_ok, parse_pretooluse_stdin
+
+# Long form — preferred when you need to inject stderr/stdin in tests:
+runner = HookRunner()
+payload = runner.parse_pretooluse_stdin()
+if payload.get("tool_name") != "Bash":
+    runner.exit_ok()
+command = payload.get("tool_input", {}).get("command", "")
+if "--no-verify" in command:
+    runner.exit_with_block("--no-verify は禁止です。")
+runner.exit_ok()
+```
+
+### Behaviour
+
+- `parse_pretooluse_stdin()`: empty stdin → returns `{}`. Malformed JSON
+  → `exit_with_block` (fail closed).
+- `exit_with_block(message)`: writes `{prefix}{message}\n` to stderr,
+  flushes, exits 2. Never returns.
+- `exit_ok()`: exits 0. Never returns.
+- The block-message prefix defaults to `"ブロック: "` and is resolved in
+  this priority order: explicit constructor argument →
+  `CORE_HARNESS_BLOCK_PREFIX` env var → `DEFAULT_BLOCK_PREFIX`.
+
+## 3. Bash helper API
+
+Hooks source the library by resolving its path through Python:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+LIB_DIR=$(python3 -c 'import core_harness.hooks; print(core_harness.hooks.lib_path())')
+# shellcheck source=/dev/null
+source "$LIB_DIR/core_harness_hooks.sh"
+
+require_dependency jq awk
+
+cmd=$(read_pretooluse_command)
+[[ -z "$cmd" ]] && exit 0
+
+# … org-specific deny logic …
+
+exit 0
+```
+
+### Public functions
+
+| Function | Purpose |
+|---|---|
+| `block_with_message <reason>` | stderr prefix + exit 2. |
+| `require_dependency <bin> [<bin> …]` | Fail closed if any binary missing. |
+| `read_pretooluse_command` | Print `.tool_input.command` (or empty). |
+| `read_pretooluse_file_path` | Print `.tool_input.file_path` (or empty). |
+| `read_pretooluse_tool_name` | Print `.tool_name` (or empty). |
+| `split_segments` | Quote-aware command-string splitter. |
+| `flatten_substitutions` | Reveal `$(…)` / `` `…` `` bodies. |
+| `collect_assignments` | Extract `VAR=value` chains. |
+| `expand_known_vars VAR=val …` | Substitute `$VAR` / `${VAR}`. |
+| `unwrap_eval_and_bashc` | Reveal `eval` / `bash -c` / `sh -c` argument bodies. |
+
+The `read_pretooluse_*` helpers cache stdin internally, so a single hook
+can call several without re-reading stdin.
+
+## 4. Contract guarantees vs. responsibilities
+
+`core-harness` owns:
+
+- The wire format documented above.
+- The Python / bash helper APIs.
+- The set of generic command-string parsers (segment splitting, eval
+  unwrapping, command-substitution flattening) — these are reusable
+  across consumers and grouped in the framework so bug fixes propagate.
+
+`core-harness` does **not** own:
+
+- Any specific deny rule (no `--no-verify` blocker, no `git push`
+  blocker, no path-based file boundary). Those live in the consumer
+  repo, which composes the framework helpers with its own policy.
+- Any role catalogue (no `secretary`, `dispatcher`, `worker`).
+- Path-normalisation helpers tied to the consumer's directory layout —
+  consumers ship those alongside their org-specific hooks.
+
+## 5. Backward compatibility
+
+The default block-message prefix `"ブロック: "` exists solely to keep the
+original consumer's existing hook test suite green during the 0.x
+transition. New consumers SHOULD set `CORE_HARNESS_BLOCK_PREFIX` to a
+value appropriate for their locale (e.g. `"BLOCKED: "`). The default
+may be retired no earlier than 1.0, with a deprecation warning at
+0.(N-1).
+
+## 6. Open questions tracked for 1.0
+
+- Typed (JSON) stderr alternative — see inventory §5.2.5. Not in 0.x.
+- PostToolUse / Stop / Notification / SubagentStop hook contracts — not
+  used by any current consumer. Will be added if/when a consumer
+  requires them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "core-harness"
-version = "0.1.0"
+version = "0.2.0"
 description = "Reusable safety primitives for Claude Code orchestrator harnesses"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -25,3 +25,4 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "core_harness.schema" = ["framework_schema.json"]
+"core_harness.hooks" = ["lib/*.sh"]

--- a/src/core_harness/hooks/__init__.py
+++ b/src/core_harness/hooks/__init__.py
@@ -1,18 +1,158 @@
-"""Hook runner protocol. 0.0.1 placeholder.
+"""Hook framework primitives — Step C (0.2.0).
 
-Hook script paths are configurable by the consumer; ``core-harness`` does not
-hard-code script locations. Default path conventions are TBD and will be
-introduced in a later minor.
+Layer 1 framework slice for PreToolUse hook wiring. Owns:
+
+- The exit-code / stdin / stderr contract used by hook scripts.
+- A small Python helper (``HookRunner`` and module-level functions) so
+  Python-implemented hooks don't have to hand-roll ``json.load(sys.stdin)``
+  + ``sys.exit`` boilerplate.
+- A path-configurable bash companion library shipped under ``hooks/lib/``
+  and exposed via :func:`lib_path`. Consumers ``source`` it from their
+  org-specific hook scripts.
+
+The framework deliberately knows **nothing** about consumer-specific
+concepts: no role names, no path patterns, no Japanese-only string
+constants. The default block-message prefix matches the legacy
+contract for backward compatibility with the original consumer's hook
+tests, but it is overridable via the ``CORE_HARNESS_BLOCK_PREFIX``
+environment variable or ``HookRunner(block_prefix=...)`` argument so
+non-Japanese consumers can localise without forking.
+
+See ``docs/hook-contract.md`` for the full specification.
 """
 
-from typing import Any, Protocol, runtime_checkable
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, IO, Mapping, Optional
+
+DEFAULT_BLOCK_PREFIX = "ブロック: "
+"""Legacy block-message prefix preserved for the original consumer.
+
+Overridable per-process via ``CORE_HARNESS_BLOCK_PREFIX`` or per-runner
+via ``HookRunner(block_prefix=...)``.
+"""
+
+BLOCK_EXIT_CODE = 2
+ALLOW_EXIT_CODE = 0
 
 
-@runtime_checkable
-class HookRunner(Protocol):
-    """Protocol for executing harness hooks. Concrete shape TBD in 0.1+."""
+def _resolve_prefix(explicit: Optional[str]) -> str:
+    if explicit is not None:
+        return explicit
+    env = os.environ.get("CORE_HARNESS_BLOCK_PREFIX")
+    if env is not None:
+        return env
+    return DEFAULT_BLOCK_PREFIX
 
-    def run(self, *args: Any, **kwargs: Any) -> Any: ...
+
+def lib_path() -> Path:
+    """Return the on-disk directory containing the bash companion lib.
+
+    Bash hooks source the lib via::
+
+        source "$(python -c 'import core_harness.hooks; print(core_harness.hooks.lib_path())')/core_harness_hooks.sh"
+
+    The directory contains org-neutral helpers only; consumer-specific
+    matching logic lives in the consumer repo.
+    """
+    return Path(__file__).resolve().parent / "lib"
 
 
-__all__ = ["HookRunner"]
+class HookRunner:
+    """Helper for Python-implemented PreToolUse hooks.
+
+    The framework contract is intentionally minimal — three operations:
+
+    - :meth:`parse_pretooluse_stdin` reads and JSON-decodes the hook
+      payload Claude Code delivers on stdin.
+    - :meth:`exit_with_block` writes ``{prefix}{message}`` to stderr and
+      exits ``2``. The prefix defaults to the legacy
+      ``"ブロック: "`` string for compatibility, but is overridable.
+    - :meth:`exit_ok` exits ``0``.
+
+    Instances are cheap; create one per hook invocation.
+    """
+
+    def __init__(
+        self,
+        *,
+        block_prefix: Optional[str] = None,
+        stderr: Optional[IO[str]] = None,
+        stdin: Optional[IO[str]] = None,
+    ) -> None:
+        self.block_prefix = _resolve_prefix(block_prefix)
+        self._stderr = stderr if stderr is not None else sys.stderr
+        self._stdin = stdin if stdin is not None else sys.stdin
+
+    def parse_pretooluse_stdin(self) -> Mapping[str, Any]:
+        """Read the PreToolUse JSON payload from stdin.
+
+        Empty stdin is treated as an empty payload (``{}``), matching
+        the de-facto contract where hooks receive ``{}`` for tools they
+        don't care about and exit 0. Malformed JSON triggers
+        :meth:`exit_with_block` so the framework fails closed rather
+        than silently allowing through a tool call whose payload it
+        couldn't inspect.
+        """
+        raw = self._stdin.read()
+        if not raw or not raw.strip():
+            return {}
+        try:
+            payload = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            self.exit_with_block(
+                f"PreToolUse JSON のパースに失敗しました: {exc}"
+            )
+        if not isinstance(payload, dict):
+            self.exit_with_block(
+                "PreToolUse payload が JSON object ではありません"
+            )
+        return payload
+
+    def exit_with_block(self, message: str) -> "Any":
+        """Write the deny reason to stderr and exit with code 2.
+
+        Never returns. The annotation is ``Any`` so callers can write
+        ``return runner.exit_with_block(...)`` if they prefer.
+        """
+        self._stderr.write(f"{self.block_prefix}{message}\n")
+        try:
+            self._stderr.flush()
+        except Exception:
+            pass
+        sys.exit(BLOCK_EXIT_CODE)
+
+    def exit_ok(self) -> "Any":
+        """Exit with code 0 (allow). Never returns."""
+        sys.exit(ALLOW_EXIT_CODE)
+
+
+def parse_pretooluse_stdin() -> Mapping[str, Any]:
+    """Module-level convenience: ``HookRunner().parse_pretooluse_stdin()``."""
+    return HookRunner().parse_pretooluse_stdin()
+
+
+def exit_with_block(message: str) -> "Any":
+    """Module-level convenience: ``HookRunner().exit_with_block(message)``."""
+    HookRunner().exit_with_block(message)
+
+
+def exit_ok() -> "Any":
+    """Module-level convenience: ``HookRunner().exit_ok()``."""
+    HookRunner().exit_ok()
+
+
+__all__ = [
+    "ALLOW_EXIT_CODE",
+    "BLOCK_EXIT_CODE",
+    "DEFAULT_BLOCK_PREFIX",
+    "HookRunner",
+    "exit_ok",
+    "exit_with_block",
+    "lib_path",
+    "parse_pretooluse_stdin",
+]

--- a/src/core_harness/hooks/__init__.py
+++ b/src/core_harness/hooks/__init__.py
@@ -11,12 +11,13 @@ Layer 1 framework slice for PreToolUse hook wiring. Owns:
   org-specific hook scripts.
 
 The framework deliberately knows **nothing** about consumer-specific
-concepts: no role names, no path patterns, no Japanese-only string
-constants. The default block-message prefix matches the legacy
-contract for backward compatibility with the original consumer's hook
-tests, but it is overridable via the ``CORE_HARNESS_BLOCK_PREFIX``
-environment variable or ``HookRunner(block_prefix=...)`` argument so
-non-Japanese consumers can localise without forking.
+concepts: no role names, no path patterns, no consumer-locale string
+constants. The default block-message prefix is the neutral English
+``"Blocked: "``; consumers that need a different prefix (e.g.
+claude-org-ja's ``"ブロック: "`` contract) inject it via the
+``CORE_HARNESS_BLOCK_PREFIX`` environment variable or
+``HookRunner(block_prefix=...)`` argument. Layer 1 stays unaware of
+any specific consumer.
 
 See ``docs/hook-contract.md`` for the full specification.
 """
@@ -29,11 +30,14 @@ import sys
 from pathlib import Path
 from typing import Any, IO, Mapping, Optional
 
-DEFAULT_BLOCK_PREFIX = "ブロック: "
-"""Legacy block-message prefix preserved for the original consumer.
+DEFAULT_BLOCK_PREFIX = "Blocked: "
+"""Default block-message prefix.
 
-Overridable per-process via ``CORE_HARNESS_BLOCK_PREFIX`` or per-runner
-via ``HookRunner(block_prefix=...)``.
+Layer-1-neutral English; consumers with org-specific localisation
+(e.g. claude-org-ja's legacy ``"ブロック: "`` contract) override this
+per-process via ``CORE_HARNESS_BLOCK_PREFIX`` or per-runner via
+``HookRunner(block_prefix=...)``. The framework intentionally does not
+ship any consumer-specific string as a default.
 """
 
 BLOCK_EXIT_CODE = 2
@@ -70,8 +74,8 @@ class HookRunner:
     - :meth:`parse_pretooluse_stdin` reads and JSON-decodes the hook
       payload Claude Code delivers on stdin.
     - :meth:`exit_with_block` writes ``{prefix}{message}`` to stderr and
-      exits ``2``. The prefix defaults to the legacy
-      ``"ブロック: "`` string for compatibility, but is overridable.
+      exits ``2``. The prefix defaults to ``"Blocked: "`` (neutral
+      English); consumers override via env var or constructor arg.
     - :meth:`exit_ok` exits ``0``.
 
     Instances are cheap; create one per hook invocation.

--- a/src/core_harness/hooks/lib/core_harness_hooks.sh
+++ b/src/core_harness/hooks/lib/core_harness_hooks.sh
@@ -20,9 +20,10 @@
 #   expand_known_vars VAR=val ...          — substitute $VAR / ${VAR}
 #   unwrap_eval_and_bashc                  — pull eval / bash -c / sh -c arguments
 #
-# The block-message prefix defaults to "ブロック: " for back-compat with
-# the original consumer's hook tests; export CORE_HARNESS_BLOCK_PREFIX
-# to override (must include any trailing punctuation/space).
+# The block-message prefix defaults to the neutral English "Blocked: ";
+# consumers that need a different locale-specific prefix (e.g. claude-
+# org-ja's "ブロック: ") export CORE_HARNESS_BLOCK_PREFIX before sourcing
+# this file (must include any trailing punctuation/space).
 #
 # Idempotent: safe to source twice in the same shell.
 
@@ -31,7 +32,7 @@ if [[ -n "${__CORE_HARNESS_HOOKS_SH_SOURCED:-}" ]]; then
 fi
 __CORE_HARNESS_HOOKS_SH_SOURCED=1
 
-: "${CORE_HARNESS_BLOCK_PREFIX:=ブロック: }"
+: "${CORE_HARNESS_BLOCK_PREFIX:=Blocked: }"
 
 # block_with_message <reason>
 #   Print "<prefix><reason>" to stderr and exit 2.

--- a/src/core_harness/hooks/lib/core_harness_hooks.sh
+++ b/src/core_harness/hooks/lib/core_harness_hooks.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# core_harness_hooks.sh — Layer 1 framework slice for bash PreToolUse hooks.
+#
+# This library is path-configurable: consumers locate it at runtime via
+#   python -c 'import core_harness.hooks; print(core_harness.hooks.lib_path())'
+# and then `source "$LIB_DIR/core_harness_hooks.sh"`. core-harness ships
+# only org-neutral helpers here; consumer-specific deny logic
+# (path patterns, role names, repo-specific allowlists) lives in the
+# consumer repo and calls into these helpers.
+#
+# Public API (stable for 0.x):
+#   block_with_message <reason>            — stderr prefix + exit 2
+#   require_dependency <bin> [bin...]      — fail-closed dep check
+#   read_pretooluse_command                — print .tool_input.command from stdin JSON
+#   read_pretooluse_file_path              — print .tool_input.file_path from stdin JSON
+#   read_pretooluse_tool_name              — print .tool_name from stdin JSON
+#   split_segments                         — quote-aware ; && || | NL splitter
+#   flatten_substitutions                  — append $(...) / `...` bodies
+#   collect_assignments                    — extract VAR=value assignments
+#   expand_known_vars VAR=val ...          — substitute $VAR / ${VAR}
+#   unwrap_eval_and_bashc                  — pull eval / bash -c / sh -c arguments
+#
+# The block-message prefix defaults to "ブロック: " for back-compat with
+# the original consumer's hook tests; export CORE_HARNESS_BLOCK_PREFIX
+# to override (must include any trailing punctuation/space).
+#
+# Idempotent: safe to source twice in the same shell.
+
+if [[ -n "${__CORE_HARNESS_HOOKS_SH_SOURCED:-}" ]]; then
+  return 0 2>/dev/null || true
+fi
+__CORE_HARNESS_HOOKS_SH_SOURCED=1
+
+: "${CORE_HARNESS_BLOCK_PREFIX:=ブロック: }"
+
+# block_with_message <reason>
+#   Print "<prefix><reason>" to stderr and exit 2.
+block_with_message() {
+  local reason="${1:-}"
+  printf '%s%s\n' "${CORE_HARNESS_BLOCK_PREFIX}" "${reason}" >&2
+  exit 2
+}
+
+# require_dependency <bin> [<bin> ...]
+#   Verify every named binary is on PATH; if any is missing, block.
+#   This is the framework default for fail-closed dependency checks.
+require_dependency() {
+  local bin
+  for bin in "$@"; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      block_with_message "$bin がインストールされていません。セキュリティ Hook の実行に必要です。"
+    fi
+  done
+}
+
+# Internal: read stdin JSON once, cache in a process-scoped temp.
+# Hooks that call multiple read_pretooluse_* helpers should use this
+# pattern via the public helpers (which all hit the cache).
+__core_harness_read_stdin_once() {
+  if [[ -z "${__CORE_HARNESS_PRETOOLUSE_INPUT+x}" ]]; then
+    if ! command -v jq >/dev/null 2>&1; then
+      block_with_message "jq がインストールされていません。セキュリティ Hook の実行に必要です。"
+    fi
+    __CORE_HARNESS_PRETOOLUSE_INPUT=$(cat)
+  fi
+}
+
+# read_pretooluse_command
+#   Print the value of .tool_input.command (Bash tool) or empty.
+read_pretooluse_command() {
+  __core_harness_read_stdin_once
+  printf '%s' "$__CORE_HARNESS_PRETOOLUSE_INPUT" | jq -r '.tool_input.command // empty'
+}
+
+# read_pretooluse_file_path
+#   Print the value of .tool_input.file_path (Edit/Write tool) or empty.
+read_pretooluse_file_path() {
+  __core_harness_read_stdin_once
+  printf '%s' "$__CORE_HARNESS_PRETOOLUSE_INPUT" | jq -r '.tool_input.file_path // empty'
+}
+
+# read_pretooluse_tool_name
+#   Print the value of .tool_name or empty.
+read_pretooluse_tool_name() {
+  __core_harness_read_stdin_once
+  printf '%s' "$__CORE_HARNESS_PRETOOLUSE_INPUT" | jq -r '.tool_name // empty'
+}
+
+# ---------------------------------------------------------------------------
+# Generic Bash command-string parser. Originally claude-org-ja's
+# `.hooks/lib/segment-split.sh` — moved here as the framework slice
+# because nothing in these helpers is consumer-specific (no role names,
+# no path patterns). Bug fixes propagate to all consumers.
+# ---------------------------------------------------------------------------
+
+# split_segments
+#   Read a Bash command string from stdin; print one segment per line,
+#   splitting on ; && || | and unquoted newlines. Honours single/double
+#   quotes and $(...) / `...` boundaries.
+split_segments() {
+  awk '
+    BEGIN { in_dq=0; in_sq=0; in_bt=0; paren_depth=0; seg=""; }
+    {
+      if(NR>1 && in_dq==0 && in_sq==0 && in_bt==0 && paren_depth==0) { print seg; seg=""; }
+      else if(NR>1) { seg = seg "\n"; }
+      line=$0
+      n=length(line)
+      i=1
+      while(i<=n) {
+        c=substr(line,i,1)
+        next_c = (i<n) ? substr(line,i+1,1) : ""
+        if(in_sq==1) {
+          if(c=="\x27"){ in_sq=0 }
+          seg=seg c; i++; continue
+        }
+        if(in_dq==1) {
+          if(c=="\""){ in_dq=0; seg=seg c; i++; continue }
+          if(c=="$" && next_c=="("){ paren_depth++; seg=seg c; i++; continue }
+          if(paren_depth>0) {
+            if(c=="(") paren_depth++
+            if(c==")") paren_depth--
+          }
+          seg=seg c; i++; continue
+        }
+        if(in_bt==1) {
+          if(c=="`"){ in_bt=0 }
+          seg=seg c; i++; continue
+        }
+        if(c=="\""){ in_dq=1; seg=seg c; i++; continue }
+        if(c=="\x27"){ in_sq=1; seg=seg c; i++; continue }
+        if(c=="`"){ in_bt=1; seg=seg c; i++; continue }
+        if(c=="$" && next_c=="("){ paren_depth++; seg=seg c; i++; continue }
+        if(paren_depth>0) {
+          if(c=="(") paren_depth++
+          if(c==")") paren_depth--
+          seg=seg c; i++; continue
+        }
+        if(c==";"){ print seg; seg=""; i++; continue }
+        if(c=="&" && next_c=="&"){ print seg; seg=""; i+=2; continue }
+        if(c=="|" && next_c=="|"){ print seg; seg=""; i+=2; continue }
+        if(c=="|"){ print seg; seg=""; i++; continue }
+        seg=seg c; i++
+      }
+    }
+    END { if(length(seg)>0) print seg }
+  '
+}
+
+# flatten_substitutions
+#   Read one segment from stdin; print the segment with $(...) and `...`
+#   bodies appended (space-separated) so downstream regex matching can
+#   see flag tokens hidden behind command substitution. Quote chars in
+#   the appended portion are squashed to spaces.
+#
+#   Limitations: 1-level nesting only; $((arith)) ignored.
+flatten_substitutions() {
+  awk '
+    {
+      out = $0
+      s = $0
+      while (match(s, /\$\([^()]*\)/)) {
+        body = substr(s, RSTART+2, RLENGTH-3)
+        out = out " " body
+        s = substr(s, RSTART+RLENGTH)
+      }
+      s = $0
+      while (match(s, /`[^`]*`/)) {
+        body = substr(s, RSTART+1, RLENGTH-2)
+        out = out " " body
+        s = substr(s, RSTART+RLENGTH)
+      }
+      gsub(/[\047\042]/, " ", out)
+      print out
+    }
+  '
+}
+
+# collect_assignments
+#   Read multiple segments from stdin (one per line); print one
+#   `VAR=value` line per detected assignment.
+#
+#   Handles: leading VAR=val, `export VAR=val`, multi-assign chains
+#   `A=1 B=2 cmd`, and command-substitution values `VAR=$(cmd)` (body
+#   appended for downstream regex).
+collect_assignments() {
+  awk '
+    function emit_assign(var, val,    flat, body, s) {
+      flat = val
+      s = val
+      while (match(s, /\$\([^()]*\)/)) {
+        body = substr(s, RSTART+2, RLENGTH-3)
+        flat = flat " " body
+        s = substr(s, RSTART+RLENGTH)
+      }
+      s = val
+      while (match(s, /`[^`]*`/)) {
+        body = substr(s, RSTART+1, RLENGTH-2)
+        flat = flat " " body
+        s = substr(s, RSTART+RLENGTH)
+      }
+      gsub(/[\047\042]/, " ", flat)
+      print var "=" flat
+    }
+    {
+      seg = $0
+      sub(/^[ \t]+/, "", seg)
+      if (match(seg, /^export[ \t]+/)) {
+        seg = substr(seg, RLENGTH + 1)
+        sub(/^[ \t]+/, "", seg)
+      }
+      while (match(seg, /^[A-Za-z_][A-Za-z0-9_]*=/)) {
+        var = substr(seg, 1, RLENGTH - 1)
+        rest = substr(seg, RLENGTH + 1)
+        val = ""; n = length(rest)
+        in_dq = 0; in_sq = 0; in_bt = 0; paren_depth = 0; i = 1
+        while (i <= n) {
+          c = substr(rest, i, 1)
+          next_c = (i < n) ? substr(rest, i+1, 1) : ""
+          if (in_sq) {
+            if (c == "\x27") { in_sq = 0; i++; continue }
+            val = val c; i++; continue
+          }
+          if (in_dq) {
+            if (c == "\"") { in_dq = 0; i++; continue }
+            if (c == "$" && next_c == "(") { paren_depth++; val = val c; i++; continue }
+            if (paren_depth > 0) {
+              if (c == "(") paren_depth++
+              if (c == ")") paren_depth--
+            }
+            val = val c; i++; continue
+          }
+          if (in_bt) {
+            if (c == "`") { in_bt = 0 }
+            val = val c; i++; continue
+          }
+          if (c == "\"") { in_dq = 1; i++; continue }
+          if (c == "\x27") { in_sq = 1; i++; continue }
+          if (c == "`") { in_bt = 1; val = val c; i++; continue }
+          if (c == "$" && next_c == "(") { paren_depth++; val = val c; i++; continue }
+          if (paren_depth > 0) {
+            if (c == "(") paren_depth++
+            if (c == ")") paren_depth--
+            val = val c; i++; continue
+          }
+          if (c == " " || c == "\t") break
+          val = val c; i++
+        }
+        if (length(val) > 0) emit_assign(var, val)
+        seg = substr(rest, i + 1)
+        sub(/^[ \t]+/, "", seg)
+      }
+    }
+  '
+}
+
+# unwrap_eval_and_bashc
+#   Read segments from stdin; print eval / bash -c / sh -c argument
+#   bodies as additional segments (one per line). Up to 2 levels deep.
+unwrap_eval_and_bashc() {
+  local current next iter
+  current=$(cat)
+  [[ -z "$current" ]] && return 0
+  for iter in 1 2; do
+    next=$(printf '%s\n' "$current" | __core_harness_unwrap_pass)
+    [[ -z "$next" ]] && break
+    printf '%s\n' "$next"
+    current="$next"
+  done
+}
+
+__core_harness_unwrap_pass() {
+  awk '
+    function emit_body(body) {
+      if (length(body) > 0) print body
+    }
+    {
+      line = $0
+      while (1) {
+        if (match(line, /(^|[^A-Za-z0-9_-])(eval|bash[ \t]+-c|sh[ \t]+-c)[ \t]+"[^"]*"/)) {
+          tok = substr(line, RSTART, RLENGTH)
+          q = index(tok, "\"")
+          emit_body(substr(tok, q+1, length(tok)-q-1))
+          line = substr(line, RSTART+RLENGTH)
+          continue
+        }
+        if (match(line, /(^|[^A-Za-z0-9_-])(eval|bash[ \t]+-c|sh[ \t]+-c)[ \t]+\047[^\047]*\047/)) {
+          tok = substr(line, RSTART, RLENGTH)
+          q = index(tok, "\047")
+          emit_body(substr(tok, q+1, length(tok)-q-1))
+          line = substr(line, RSTART+RLENGTH)
+          continue
+        }
+        if (match(line, /(^|[^A-Za-z0-9_-])eval[ \t]+[^ \t"\047;&|`][^ \t;&|`]*/)) {
+          tok = substr(line, RSTART, RLENGTH)
+          eidx = index(tok, "eval")
+          if (eidx > 0) {
+            after = substr(tok, eidx + 4)
+            sub(/^[ \t]+/, "", after)
+            emit_body(after)
+          }
+          line = substr(line, RSTART+RLENGTH)
+          continue
+        }
+        break
+      }
+    }
+  '
+}
+
+# expand_known_vars VAR=val [VAR=val ...]
+#   Read one segment from stdin; print the segment with $VAR / ${VAR}
+#   references replaced by their values. Word-boundary aware so $FOOBAR
+#   is not replaced when only FOO is known.
+expand_known_vars() {
+  local segment
+  segment=$(cat)
+  local pair var val
+  for pair in "$@"; do
+    var="${pair%%=*}"
+    val="${pair#*=}"
+    segment="${segment//\$\{$var\}/$val}"
+    segment=$(printf '%s' "$segment" | awk -v v="$var" -v r="$val" '
+      {
+        out = ""; n = length($0); i = 1
+        while (i <= n) {
+          c = substr($0, i, 1)
+          if (c == "$" && i < n) {
+            rest = substr($0, i+1)
+            if (match(rest, "^" v "([^A-Za-z0-9_]|$)")) {
+              out = out r
+              i = i + 1 + length(v)
+              continue
+            }
+          }
+          out = out c
+          i = i + 1
+        }
+        print out
+      }
+    ')
+  done
+  printf '%s\n' "$segment"
+}

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -42,7 +42,22 @@ class LibPathTests(unittest.TestCase):
         self.assertIsInstance(lib_path(), Path)
 
 
+class DefaultPrefixTests(unittest.TestCase):
+    def test_default_is_neutral_english(self) -> None:
+        # Layer-1 purity: the default ships no consumer-specific locale.
+        # Consumers (e.g. claude-org-ja's "ブロック: ") inject their
+        # own prefix via env or constructor arg.
+        self.assertEqual(DEFAULT_BLOCK_PREFIX, "Blocked: ")
+
+
 class ParseStdinTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved_env = os.environ.pop("CORE_HARNESS_BLOCK_PREFIX", None)
+
+    def tearDown(self) -> None:
+        if self._saved_env is not None:
+            os.environ["CORE_HARNESS_BLOCK_PREFIX"] = self._saved_env
+
     def _runner(self, raw: str, *, stderr: io.StringIO | None = None) -> HookRunner:
         return HookRunner(
             stdin=io.StringIO(raw),
@@ -88,12 +103,32 @@ class ParseStdinTests(unittest.TestCase):
 
 class ExitTests(unittest.TestCase):
     def test_exit_with_block_writes_default_prefix(self) -> None:
+        old = os.environ.pop("CORE_HARNESS_BLOCK_PREFIX", None)
+        try:
+            stderr = io.StringIO()
+            runner = HookRunner(stderr=stderr, stdin=io.StringIO(""))
+            with self.assertRaises(SystemExit) as cm:
+                runner.exit_with_block("test reason")
+            self.assertEqual(cm.exception.code, BLOCK_EXIT_CODE)
+            self.assertEqual(stderr.getvalue(), f"{DEFAULT_BLOCK_PREFIX}test reason\n")
+            self.assertTrue(stderr.getvalue().startswith("Blocked: "))
+        finally:
+            if old is not None:
+                os.environ["CORE_HARNESS_BLOCK_PREFIX"] = old
+
+    def test_consumer_can_inject_legacy_japanese_prefix(self) -> None:
+        # Regression: the override path is the contract claude-org-ja
+        # relies on to keep its 380+ existing hook tests green during
+        # the 0.x transition. Don't break this.
         stderr = io.StringIO()
-        runner = HookRunner(stderr=stderr, stdin=io.StringIO(""))
-        with self.assertRaises(SystemExit) as cm:
-            runner.exit_with_block("test reason")
-        self.assertEqual(cm.exception.code, BLOCK_EXIT_CODE)
-        self.assertEqual(stderr.getvalue(), f"{DEFAULT_BLOCK_PREFIX}test reason\n")
+        runner = HookRunner(
+            stderr=stderr,
+            stdin=io.StringIO(""),
+            block_prefix="ブロック: ",
+        )
+        with self.assertRaises(SystemExit):
+            runner.exit_with_block("テスト理由")
+        self.assertEqual(stderr.getvalue(), "ブロック: テスト理由\n")
 
     def test_exit_with_block_uses_explicit_prefix(self) -> None:
         stderr = io.StringIO()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,212 @@
+"""Hook framework tests (Step C / 0.2).
+
+Generic only — no consumer-org strings. Exercises the contract documented
+in ``docs/hook-contract.md``: stdin JSON parse, exit code semantics,
+stderr block-prefix resolution, and that ``lib_path()`` resolves to a
+directory containing the bash companion library.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from core_harness import hooks
+from core_harness.hooks import (
+    ALLOW_EXIT_CODE,
+    BLOCK_EXIT_CODE,
+    DEFAULT_BLOCK_PREFIX,
+    HookRunner,
+    lib_path,
+)
+
+
+class LibPathTests(unittest.TestCase):
+    def test_lib_path_is_directory(self) -> None:
+        p = lib_path()
+        self.assertTrue(p.is_dir(), f"{p} should be a directory")
+
+    def test_lib_path_contains_companion_script(self) -> None:
+        script = lib_path() / "core_harness_hooks.sh"
+        self.assertTrue(
+            script.is_file(),
+            f"{script} should ship with the package",
+        )
+
+    def test_lib_path_returns_path_object(self) -> None:
+        self.assertIsInstance(lib_path(), Path)
+
+
+class ParseStdinTests(unittest.TestCase):
+    def _runner(self, raw: str, *, stderr: io.StringIO | None = None) -> HookRunner:
+        return HookRunner(
+            stdin=io.StringIO(raw),
+            stderr=stderr or io.StringIO(),
+        )
+
+    def test_empty_stdin_returns_empty_dict(self) -> None:
+        self.assertEqual(self._runner("").parse_pretooluse_stdin(), {})
+
+    def test_whitespace_only_returns_empty_dict(self) -> None:
+        self.assertEqual(self._runner("   \n\t").parse_pretooluse_stdin(), {})
+
+    def test_round_trip_payload(self) -> None:
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hello"},
+        }
+        result = self._runner(json.dumps(payload)).parse_pretooluse_stdin()
+        self.assertEqual(result, payload)
+
+    def test_unicode_round_trip(self) -> None:
+        payload = {"tool_name": "Bash", "tool_input": {"command": "echo こんにちは"}}
+        result = self._runner(json.dumps(payload, ensure_ascii=False)).parse_pretooluse_stdin()
+        self.assertEqual(result, payload)
+
+    def test_invalid_json_blocks(self) -> None:
+        stderr = io.StringIO()
+        runner = self._runner("{not json", stderr=stderr)
+        with self.assertRaises(SystemExit) as cm:
+            runner.parse_pretooluse_stdin()
+        self.assertEqual(cm.exception.code, BLOCK_EXIT_CODE)
+        self.assertTrue(stderr.getvalue().startswith(DEFAULT_BLOCK_PREFIX))
+        self.assertIn("PreToolUse JSON", stderr.getvalue())
+
+    def test_non_object_payload_blocks(self) -> None:
+        stderr = io.StringIO()
+        runner = self._runner("[1, 2, 3]", stderr=stderr)
+        with self.assertRaises(SystemExit) as cm:
+            runner.parse_pretooluse_stdin()
+        self.assertEqual(cm.exception.code, BLOCK_EXIT_CODE)
+        self.assertTrue(stderr.getvalue().startswith(DEFAULT_BLOCK_PREFIX))
+
+
+class ExitTests(unittest.TestCase):
+    def test_exit_with_block_writes_default_prefix(self) -> None:
+        stderr = io.StringIO()
+        runner = HookRunner(stderr=stderr, stdin=io.StringIO(""))
+        with self.assertRaises(SystemExit) as cm:
+            runner.exit_with_block("test reason")
+        self.assertEqual(cm.exception.code, BLOCK_EXIT_CODE)
+        self.assertEqual(stderr.getvalue(), f"{DEFAULT_BLOCK_PREFIX}test reason\n")
+
+    def test_exit_with_block_uses_explicit_prefix(self) -> None:
+        stderr = io.StringIO()
+        runner = HookRunner(
+            stderr=stderr,
+            stdin=io.StringIO(""),
+            block_prefix="BLOCKED: ",
+        )
+        with self.assertRaises(SystemExit) as cm:
+            runner.exit_with_block("nope")
+        self.assertEqual(cm.exception.code, BLOCK_EXIT_CODE)
+        self.assertEqual(stderr.getvalue(), "BLOCKED: nope\n")
+
+    def test_exit_with_block_uses_env_prefix(self) -> None:
+        stderr = io.StringIO()
+        old = os.environ.get("CORE_HARNESS_BLOCK_PREFIX")
+        os.environ["CORE_HARNESS_BLOCK_PREFIX"] = "DENY> "
+        try:
+            runner = HookRunner(stderr=stderr, stdin=io.StringIO(""))
+            with self.assertRaises(SystemExit):
+                runner.exit_with_block("x")
+            self.assertEqual(stderr.getvalue(), "DENY> x\n")
+        finally:
+            if old is None:
+                os.environ.pop("CORE_HARNESS_BLOCK_PREFIX", None)
+            else:
+                os.environ["CORE_HARNESS_BLOCK_PREFIX"] = old
+
+    def test_explicit_arg_beats_env(self) -> None:
+        stderr = io.StringIO()
+        old = os.environ.get("CORE_HARNESS_BLOCK_PREFIX")
+        os.environ["CORE_HARNESS_BLOCK_PREFIX"] = "ENV: "
+        try:
+            runner = HookRunner(
+                stderr=stderr,
+                stdin=io.StringIO(""),
+                block_prefix="ARG: ",
+            )
+            with self.assertRaises(SystemExit):
+                runner.exit_with_block("x")
+            self.assertEqual(stderr.getvalue(), "ARG: x\n")
+        finally:
+            if old is None:
+                os.environ.pop("CORE_HARNESS_BLOCK_PREFIX", None)
+            else:
+                os.environ["CORE_HARNESS_BLOCK_PREFIX"] = old
+
+    def test_exit_ok_returns_zero(self) -> None:
+        runner = HookRunner(stderr=io.StringIO(), stdin=io.StringIO(""))
+        with self.assertRaises(SystemExit) as cm:
+            runner.exit_ok()
+        self.assertEqual(cm.exception.code, ALLOW_EXIT_CODE)
+
+
+class ModuleLevelHelpersTests(unittest.TestCase):
+    """Smoke-test the module-level convenience wrappers via subprocess.
+
+    Running them in-process would tear down the test runner because they
+    call ``sys.exit``; running through ``python -c`` gives us actual
+    process exit codes to assert on.
+    """
+
+    def _run(self, code: str, *, stdin: str = "") -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+
+    def test_module_exit_ok(self) -> None:
+        result = self._run("from core_harness.hooks import exit_ok; exit_ok()")
+        self.assertEqual(result.returncode, ALLOW_EXIT_CODE)
+
+    def test_module_exit_with_block(self) -> None:
+        result = self._run(
+            "from core_harness.hooks import exit_with_block; exit_with_block('boom')"
+        )
+        self.assertEqual(result.returncode, BLOCK_EXIT_CODE)
+        self.assertIn("boom", result.stderr)
+        self.assertIn(DEFAULT_BLOCK_PREFIX, result.stderr)
+
+    def test_module_parse_then_exit(self) -> None:
+        code = (
+            "import json, sys\n"
+            "from core_harness.hooks import parse_pretooluse_stdin, exit_ok\n"
+            "p = parse_pretooluse_stdin()\n"
+            "sys.stdout.write(json.dumps(p))\n"
+            "exit_ok()\n"
+        )
+        payload = {"tool_name": "Bash", "tool_input": {"command": "ls"}}
+        result = self._run(code, stdin=json.dumps(payload))
+        self.assertEqual(result.returncode, ALLOW_EXIT_CODE)
+        self.assertEqual(json.loads(result.stdout), payload)
+
+
+class PublicSurfaceTests(unittest.TestCase):
+    def test_public_symbols_exposed(self) -> None:
+        for name in (
+            "ALLOW_EXIT_CODE",
+            "BLOCK_EXIT_CODE",
+            "DEFAULT_BLOCK_PREFIX",
+            "HookRunner",
+            "exit_ok",
+            "exit_with_block",
+            "lib_path",
+            "parse_pretooluse_stdin",
+        ):
+            self.assertIn(name, hooks.__all__, f"{name} missing from __all__")
+            self.assertTrue(hasattr(hooks, name), f"{name} missing from module")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hooks_bash.sh
+++ b/tests/test_hooks_bash.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Bash-side tests for core_harness_hooks.sh (Step C / 0.2).
+#
+# Exercises: block_with_message exit code + stderr prefix, JSON
+# accessors, and the generic command-string parsers.
+#
+# Run from any directory. No claude-org fixtures.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_PATH="$SCRIPT_DIR/../src/core_harness/hooks/lib/core_harness_hooks.sh"
+
+if [[ ! -f "$LIB_PATH" ]]; then
+  echo "FAIL: lib not found at $LIB_PATH" >&2
+  exit 1
+fi
+
+# shellcheck source=../src/core_harness/hooks/lib/core_harness_hooks.sh
+source "$LIB_PATH"
+
+PASS=0
+FAIL=0
+
+# Each `check` runs the supplied test in a subshell so that
+# block_with_message's exit 2 doesn't terminate the runner.
+check() {
+  local name="$1"; shift
+  if ( "$@" ) >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  ok   %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf '  FAIL %s\n' "$name" >&2
+    ( "$@" ) || true
+  fi
+}
+
+# ----- block_with_message ---------------------------------------------------
+
+t_block_exit_code() {
+  local rc=0
+  ( block_with_message "test reason" ) 2>/dev/null || rc=$?
+  [[ $rc -eq 2 ]]
+}
+
+t_block_default_prefix() {
+  local out
+  out=$( ( block_with_message "test reason" ) 2>&1 || true )
+  [[ "$out" == "ブロック: test reason" ]]
+}
+
+t_block_env_prefix() {
+  local out
+  out=$( CORE_HARNESS_BLOCK_PREFIX="DENY> " bash -c "
+    source '$LIB_PATH'
+    block_with_message 'oops'
+  " 2>&1 || true)
+  [[ "$out" == "DENY> oops" ]]
+}
+
+# ----- require_dependency ---------------------------------------------------
+
+t_require_dep_present() {
+  local rc=0
+  ( require_dependency bash ) 2>/dev/null || rc=$?
+  [[ $rc -eq 0 ]]
+}
+
+t_require_dep_missing() {
+  local rc=0
+  ( require_dependency __nonexistent_binary_xyz_42 ) 2>/dev/null || rc=$?
+  [[ $rc -eq 2 ]]
+}
+
+# ----- read_pretooluse_* ----------------------------------------------------
+
+t_read_command() {
+  local got
+  got=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' \
+    | ( read_pretooluse_command ) )
+  [[ "$got" == "echo hi" ]]
+}
+
+t_read_file_path() {
+  local got
+  got=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x"}}' \
+    | ( read_pretooluse_file_path ) )
+  [[ "$got" == "/tmp/x" ]]
+}
+
+t_read_tool_name() {
+  local got
+  got=$(printf '{"tool_name":"Bash","tool_input":{}}' \
+    | ( read_pretooluse_tool_name ) )
+  [[ "$got" == "Bash" ]]
+}
+
+t_read_command_missing_field_empty() {
+  local got
+  got=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x"}}' \
+    | ( read_pretooluse_command ) )
+  [[ -z "$got" ]]
+}
+
+# ----- split_segments -------------------------------------------------------
+
+t_split_simple() {
+  local got
+  got=$(printf '%s' 'a; b && c | d || e' | split_segments | tr '\n' '|')
+  [[ "$got" == "a| b | c | d | e|" ]]
+}
+
+t_split_quoted_separators_preserved() {
+  # The ; inside double quotes must NOT be a segment break.
+  local got
+  got=$(printf '%s' 'git commit -m "a ; b" --no-verify' | split_segments | wc -l | tr -d ' ')
+  [[ "$got" == "1" ]]
+}
+
+t_split_command_substitution_preserved() {
+  # The | inside $(...) must NOT be a segment break.
+  local got
+  got=$(printf '%s' 'echo $(ls | wc -l)' | split_segments | wc -l | tr -d ' ')
+  [[ "$got" == "1" ]]
+}
+
+# ----- flatten_substitutions -----------------------------------------------
+
+t_flatten_dollar_paren() {
+  local got
+  got=$(printf '%s' 'git commit $(printf -- "--no-verify") -m x' | flatten_substitutions)
+  [[ "$got" == *"--no-verify"* ]]
+}
+
+t_flatten_backticks() {
+  local got
+  got=$(printf '%s' 'git commit `printf -- "--no-verify"` -m x' | flatten_substitutions)
+  [[ "$got" == *"--no-verify"* ]]
+}
+
+# ----- collect_assignments + expand_known_vars -----------------------------
+
+t_collect_simple_assign() {
+  local got
+  got=$(printf '%s' 'flag=--no-verify' | collect_assignments)
+  [[ "$got" == "flag=--no-verify" ]]
+}
+
+t_collect_export_assign() {
+  local got
+  got=$(printf '%s' 'export FOO=bar' | collect_assignments)
+  [[ "$got" == "FOO=bar" ]]
+}
+
+t_expand_known_vars() {
+  local got
+  got=$(printf '%s' 'git commit "$flag"' | expand_known_vars 'flag=--no-verify')
+  [[ "$got" == *"--no-verify"* ]]
+}
+
+t_expand_word_boundary() {
+  # $FOOBAR should not be replaced when only FOO is known.
+  local got
+  got=$(printf '%s' 'echo $FOOBAR' | expand_known_vars 'FOO=x')
+  [[ "$got" == 'echo $FOOBAR' ]]
+}
+
+# ----- unwrap_eval_and_bashc -----------------------------------------------
+
+t_unwrap_eval_double_quote() {
+  local got
+  got=$(printf '%s\n' 'eval "git commit --no-verify"' | unwrap_eval_and_bashc)
+  [[ "$got" == *"git commit --no-verify"* ]]
+}
+
+t_unwrap_bash_c_single_quote() {
+  local got
+  got=$(printf '%s\n' "bash -c 'git push --force'" | unwrap_eval_and_bashc)
+  [[ "$got" == *"git push --force"* ]]
+}
+
+t_unwrap_sh_c() {
+  local got
+  got=$(printf '%s\n' "sh -c 'rm -rf /'" | unwrap_eval_and_bashc)
+  [[ "$got" == *"rm -rf /"* ]]
+}
+
+# ---------------------------------------------------------------------------
+
+echo "running core_harness_hooks.sh tests"
+check "block_with_message exits 2"                 t_block_exit_code
+check "block_with_message default prefix"          t_block_default_prefix
+check "block_with_message env prefix override"     t_block_env_prefix
+check "require_dependency allows present binary"   t_require_dep_present
+check "require_dependency blocks missing binary"   t_require_dep_missing
+check "read_pretooluse_command"                    t_read_command
+check "read_pretooluse_file_path"                  t_read_file_path
+check "read_pretooluse_tool_name"                  t_read_tool_name
+check "read_pretooluse_command empty when absent"  t_read_command_missing_field_empty
+check "split_segments simple"                      t_split_simple
+check "split_segments preserves quoted separators" t_split_quoted_separators_preserved
+check "split_segments preserves command-sub"       t_split_command_substitution_preserved
+check "flatten_substitutions reveals dollar-paren" t_flatten_dollar_paren
+check "flatten_substitutions reveals backticks"    t_flatten_backticks
+check "collect_assignments simple"                 t_collect_simple_assign
+check "collect_assignments export form"            t_collect_export_assign
+check "expand_known_vars substitutes"              t_expand_known_vars
+check "expand_known_vars respects word boundary"   t_expand_word_boundary
+check "unwrap_eval_and_bashc double-quote"         t_unwrap_eval_double_quote
+check "unwrap_eval_and_bashc bash -c single"       t_unwrap_bash_c_single_quote
+check "unwrap_eval_and_bashc sh -c"                t_unwrap_sh_c
+
+echo
+echo "passed: $PASS"
+echo "failed: $FAIL"
+
+if [[ $FAIL -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_hooks_bash.sh
+++ b/tests/test_hooks_bash.sh
@@ -45,9 +45,27 @@ t_block_exit_code() {
 }
 
 t_block_default_prefix() {
+  # Layer-1 default is the neutral English "Blocked: ". We force a
+  # fresh sub-shell so this test is robust against an inherited
+  # CORE_HARNESS_BLOCK_PREFIX from the calling environment.
   local out
-  out=$( ( block_with_message "test reason" ) 2>&1 || true )
-  [[ "$out" == "ブロック: test reason" ]]
+  out=$(unset CORE_HARNESS_BLOCK_PREFIX; bash -c "
+    source '$LIB_PATH'
+    block_with_message 'test reason'
+  " 2>&1 || true)
+  [[ "$out" == "Blocked: test reason" ]]
+}
+
+t_block_legacy_japanese_via_env() {
+  # The override path the original consumer (claude-org-ja) uses to
+  # keep its existing 380+ hook tests green: export the legacy
+  # "ブロック: " prefix before sourcing the lib.
+  local out
+  out=$( CORE_HARNESS_BLOCK_PREFIX="ブロック: " bash -c "
+    source '$LIB_PATH'
+    block_with_message 'テスト理由'
+  " 2>&1 || true)
+  [[ "$out" == "ブロック: テスト理由" ]]
 }
 
 t_block_env_prefix() {
@@ -192,6 +210,7 @@ echo "running core_harness_hooks.sh tests"
 check "block_with_message exits 2"                 t_block_exit_code
 check "block_with_message default prefix"          t_block_default_prefix
 check "block_with_message env prefix override"     t_block_env_prefix
+check "block_with_message legacy JP via env"       t_block_legacy_japanese_via_env
 check "require_dependency allows present binary"   t_require_dep_present
 check "require_dependency blocks missing binary"   t_require_dep_missing
 check "read_pretooluse_command"                    t_read_command


### PR DESCRIPTION
Phase 3 Step C per [claude-org-ja#196 design](https://github.com/suisya-systems/claude-org-ja/blob/main/docs/design/core-harness-extraction.md). Scope is **narrowed** to the hook-framework wiring slice (Python `HookRunner` + bash `core_harness_hooks.sh` + contract doc) — the org-shaped hook bodies (`block-no-verify`, `block-dangerous-git`, `check-worker-boundary`) stay in claude-org-ja per Q4 (one-way dependency). Generic-version migration of those bodies is filed as a follow-up.

## Summary
- `core_harness.hooks`: `HookRunner` + module-level wrappers + `lib_path()` + `DEFAULT_BLOCK_PREFIX = "Blocked: "` (English neutral default for Layer 1 purity) + `BLOCK_EXIT_CODE = 2` / `ALLOW_EXIT_CODE = 0` + `CORE_HARNESS_BLOCK_PREFIX` env override
- bash `core_harness_hooks.sh` (shipped via package-data, resolved by `core_harness.hooks.lib_path()`): `block_with_message`, `require_dependency`, `read_pretooluse_{command,file_path,tool_name}`, generic parsers (`split_segments`, `flatten_substitutions`, `collect_assignments`, `expand_known_vars`, `unwrap_eval_and_bashc`)
- `docs/hook-contract.md`: stdin JSON / exit-code / stderr contract; §5 documents consumer-specific localisation
- `pyproject.toml` 0.1.0 → 0.2.0; `package-data` ships `hooks/lib/*.sh`

## Layer 1 purity
Initial draft kept `"ブロック: "` (Japanese) as the default prefix for ja test compat. Lead review flagged this as a Q4 violation — even with env override, the JP default means core-harness *knows about* claude-org-ja. Fixed in `cafeedc`: default is now `"Blocked: "` (English neutral). Consumers inject locale-specific prefixes via `CORE_HARNESS_BLOCK_PREFIX` env or constructor arg at the org boundary.

## Tests
- Python: 68 passed (`python -m pytest tests/ -q`); +11 new hook tests in V1 + 2 prefix-default regression tests in V2
- Bash: 22 passed (`bash tests/test_hooks_bash.sh`); +21 in V1 + 1 prefix-default regression in V2
- Wheel build: `pip wheel . --no-deps` confirmed `core_harness/hooks/lib/core_harness_hooks.sh` is included

## Next (after merge)
- Tag `v0.2.0`
- claude-org-ja shim PR (`feat/step-c-shim`): pin v0.2.0, source `core_harness_hooks.sh` from ja's hooks, set `CORE_HARNESS_BLOCK_PREFIX="ブロック: "` at the org boundary, keep all 380+ existing hook tests green unmodified

## Refs
- Design: claude-org-ja#196 (merged)
- ja Issue: claude-org-ja#128
- Step B (preceding release): #1 (v0.1.0)