### PR TITLE
feat: Step D — audit/journal API (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-02
+
+### Added
+
+- `core_harness.audit` (Step D — journal API, refs ja#128 / design
+  PR #196 §4 Step D):
+  - `Journal` class — append-only JSON-Lines journal with
+    consumer-supplied path. Public methods `append(event, **fields)`,
+    `iter_events(filter_event=None, since=None)`, `tail(n)`.
+  - Module-level convenience wrappers `append_event(path, event,
+    **fields)` and `iter_events(path, filter_event, since)`.
+  - Exception hierarchy: `JournalError` (parent), `JournalLockError`,
+    `JournalReadError`.
+  - Concurrent-write safety: `fcntl.flock(LOCK_EX)` on POSIX,
+    `msvcrt.locking()` on Windows, plus an in-process mutex keyed by
+    absolute path so multi-threaded appenders inside one interpreter
+    are also serialized.
+  - Reader tolerance: blank lines, broken JSON, and non-object lines
+    are skipped with a `UserWarning` (matches the de-facto contract
+    documented in inventory §4).
+- `core_harness/audit/lib/journal_append.sh` — bash companion library
+  with `journal_append <path> <event> [k=v ...]` and
+  `journal_append_raw <path>` (stdin-driven). Uses `jq` for safe JSON
+  encoding, takes `flock(1)` when available.
+- `docs/journal-contract.md` — wire-format / concurrency / reader
+  tolerance specification.
+- `tests/test_audit.py`, `tests/test_audit_bash.sh` — generic-only
+  framework tests (no consumer-org event names).
+
+### Changed
+
+- `core_harness.audit` graduated from placeholder to experimental.
+- `pyproject.toml`: bumped to 0.3.0; `core_harness.audit` now ships
+  `lib/*.sh` as package data alongside `core_harness.hooks`.
+
+### Notes
+
+- The journal file path is **consumer-injected** (Q4 one-way
+  dependency rule). Layer 1 never reads consumer-shaped env vars to
+  discover it; the consumer instantiates `Journal(Path(...))` or
+  passes the path explicitly to `append_event`.
+- The event-type catalog (e.g. `worker_spawned`, `pr_merged`, …) and
+  per-event field conventions remain in the consumer repo. Layer 1
+  owns the *how* (envelope, locking, reader tolerance), not the
+  *what*.
+
 ## [0.2.0] - 2026-05-02
 
 ### Added

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -1,19 +1,19 @@
 # Public API Surface — 0.x
 
-> **Status: 0.2.0 published.** This document tracks the evolving public
+> **Status: 0.3.0 published.** This document tracks the evolving public
 > surface during the pre-1.0 phase. Items below are *experimental*
 > unless explicitly marked `stable`; signatures may change between
 > minor versions per [`semver-policy.md`](semver-policy.md).
 
 ## Modules
 
-| Module | Status (0.2) | Notes |
+| Module | Status (0.3) | Notes |
 |---|---|---|
 | `core_harness.schema` | experimental | Framework JSON Schema + merge helper. Type-only — concrete role names / consumer regexes live in the org-extension schema (PR #196 §3). |
 | `core_harness.validator` | experimental | Audit engine for per-role `settings.local.json`. |
 | `core_harness.generator` | experimental | Worker `settings.local.json` template renderer. |
 | `core_harness.hooks` | experimental | PreToolUse hook contract (Step C, 0.2). Python helper + bash companion lib + `docs/hook-contract.md`. |
-| `core_harness.audit` | placeholder | Journal API (Step D). |
+| `core_harness.audit` | experimental | Journal API (Step D, 0.3). Python `Journal` class + bash companion lib + `docs/journal-contract.md`. |
 
 ## Public symbols (0.2)
 
@@ -86,6 +86,36 @@ Sourced via the path returned by `lib_path()`. Public functions:
   with a locale-specific contract (e.g. claude-org-ja's
   `"ブロック: "`) export this at their org boundary so Layer 1 stays
   unaware of consumer locale.
+
+### `core_harness.audit`
+
+| Symbol | Status | Purpose |
+|---|---|---|
+| `Journal(path: Path)` | experimental | Append-only JSON-Lines journal bound to a consumer-supplied path. |
+| `Journal.append(event: str, **fields) -> None` | experimental | Append one event line. Adds `ts` (ISO-8601 UTC) automatically; rejects reserved keys (`ts`, `event`) in `fields`. |
+| `Journal.iter_events(filter_event=None, since=None) -> Iterator[dict]` | experimental | Stream events; skips blank / malformed / non-object lines with `UserWarning`. |
+| `Journal.tail(n: int) -> list[dict]` | experimental | Last `n` valid events, oldest-first. |
+| `append_event(path, event, **fields) -> None` | experimental | Module-level convenience for `Journal(path).append(...)`. |
+| `iter_events(path, filter_event=None, since=None)` | experimental | Module-level convenience for `Journal(path).iter_events(...)`. |
+| `JournalError` | experimental | Base exception. |
+| `JournalLockError` | experimental | Raised when exclusive append lock cannot be acquired. |
+| `JournalReadError` | experimental | Raised when the journal file cannot be opened for reading. |
+
+#### Bash companion (`audit/lib/journal_append.sh`)
+
+Shipped as package data; consumers locate it via `pip show
+core-harness` + `src/core_harness/audit/lib/journal_append.sh`, or
+import-and-introspect from Python (`Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"`).
+Public functions: `journal_append <path> <event> [k=v ...]`,
+`journal_append_raw <path>` (stdin-driven). See
+[`journal-contract.md`](journal-contract.md) for the full spec.
+
+#### Concurrency
+
+`Journal.append` holds an exclusive file lock (`fcntl.flock` on POSIX,
+`msvcrt.locking` on Windows) plus an in-process mutex keyed by the
+resolved absolute path; concurrent appends from threads / processes
+are serialized. The bash helper uses `flock(1)` when available.
 
 ## 1.0 graduation conditions
 

--- a/docs/journal-contract.md
+++ b/docs/journal-contract.md
@@ -45,6 +45,14 @@ type system; consumers needing typed payload values from bash should
 either pre-encode JSON and use `journal_append_raw`, or call the
 Python API.
 
+The bash helper additionally restricts payload **keys** to the
+identifier-safe character class `[A-Za-z_][A-Za-z0-9_]*`. This is a
+bash-only constraint — keys are interpolated literally into a `jq`
+program and bound as `--arg` names, neither of which can be quoted at
+runtime. Consumers needing arbitrary key shapes should use the Python
+API (no such restriction) or `journal_append_raw` (which validates the
+input parses as a JSON object and re-encodes compactly).
+
 ### 1.3 Example line
 
 ```json

--- a/docs/journal-contract.md
+++ b/docs/journal-contract.md
@@ -1,0 +1,176 @@
+# Journal Contract — `core_harness.audit` (0.3+)
+
+> **Status: experimental (0.3.0).** Signature/semantics may shift before
+> 1.0 per [`semver-policy.md`](semver-policy.md). The wire format
+> (envelope keys + reader tolerance) is intended to be stable from
+> 0.3.0 onward; signature changes will be flagged in `CHANGELOG.md`.
+
+This document specifies the audit-journal primitive that
+`core_harness.audit` exposes to consumers. The framework deliberately
+owns the *how* (envelope, locking, reader tolerance) and not the
+*what* (which event names exist, which payload fields each event
+carries). Consumers own their event-type catalog.
+
+---
+
+## 1. Wire format
+
+The journal is a single file containing **one JSON object per line**
+(JSON Lines). Each line MUST be a self-contained, single-line JSON
+object terminated by `\n`.
+
+### 1.1 Reserved envelope keys
+
+Two keys are reserved by Layer 1 and present on every line written
+through `Journal.append` / `journal_append`:
+
+| Key     | Type                              | Source        | Purpose                                  |
+|---------|-----------------------------------|---------------|------------------------------------------|
+| `ts`    | string, `YYYY-MM-DDTHH:MM:SSZ`    | auto (UTC)    | Append time (ISO-8601, second precision) |
+| `event` | string, non-empty                 | caller        | Event name (free-form; consumer-defined) |
+
+Caller-supplied `**fields` MUST NOT contain these keys; the framework
+raises `ValueError` (Python) or returns exit code 2 (bash) on
+collision.
+
+### 1.2 Payload
+
+After the envelope, any number of caller-supplied keys are appended
+in insertion order. The framework places no constraints on payload
+shape: nested objects, arrays, unicode strings (`ensure_ascii=False`),
+booleans, numbers, and `null` are all permitted.
+
+The bash helper string-types every k=v argument because shell has no
+type system; consumers needing typed payload values from bash should
+either pre-encode JSON and use `journal_append_raw`, or call the
+Python API.
+
+### 1.3 Example line
+
+```json
+{"ts":"2026-05-02T12:34:56Z","event":"alpha","k":1,"label":"hello"}
+```
+
+---
+
+## 2. Path injection (Q4 one-way dependency)
+
+The journal file path is **supplied by the consumer**. Layer 1 never
+reads consumer-shaped environment variables (e.g.
+`CORE_HARNESS_JOURNAL_PATH`) on its own; consumers either:
+
+- Instantiate `Journal(Path(...))` explicitly, or
+- Call `core_harness.audit.append_event(path, event, **fields)`, or
+- Source the bash lib and pass `path` as the first arg to
+  `journal_append`.
+
+Parent directories are created on first append.
+
+---
+
+## 3. Concurrent-write safety
+
+- **POSIX**: `fcntl.flock(fd, LOCK_EX)` is held for the duration of
+  each line write. The fd is opened with `O_APPEND` so the kernel
+  positions writes at end-of-file even if the lock is contended.
+- **Windows**: `msvcrt.locking(fd, LK_LOCK, 1)` on a single-byte
+  region at offset 0. All appenders contend for the same byte, which
+  serializes them.
+- **In-process**: a module-level `threading.Lock` keyed by the
+  resolved absolute path serializes appenders inside one Python
+  interpreter (the OS-level lock alone is not sufficient — multiple
+  threads sharing one fd can interleave `os.write` calls).
+- **Bash**: when `flock(1)` (util-linux) is available the lib uses it
+  via fd 9; otherwise it falls back to `>>` append, which is atomic
+  for short writes on Linux but offers no cross-process guarantee on
+  other platforms. Consumers needing cross-platform concurrency
+  safety from non-Python code should use the Python API.
+
+Test coverage: `tests/test_audit.py::test_concurrent_append_round_trip`
+runs 20 threads × 5 appends and asserts no torn writes (every line
+parses as JSON, every (tid, i) pair is present exactly once).
+
+---
+
+## 4. Reader tolerance
+
+`Journal.iter_events` and `Journal.tail` skip:
+
+1. Blank lines (`""` or whitespace-only).
+2. Lines that fail `json.loads` (e.g. partial writes from a crashed
+   producer that did not hold the lock — should be impossible with
+   the lock contract above, but tolerated for forward-compat).
+3. Lines whose top-level value is not a JSON object (e.g. a stray
+   array literal).
+
+Skipped lines emit a `UserWarning` so retros / drift CI can detect
+corruption without bringing the read down. This matches the
+de-facto contract documented in the consumer-side inventory
+(`tests/fixtures/journal-sample.jsonl` intentionally contains a
+`not-valid-json` line).
+
+---
+
+## 5. Filters
+
+`Journal.iter_events` accepts two optional filters:
+
+- `filter_event: str | None` — exact match on the `event` field.
+- `since: str | None` — lexicographic `>=` comparison on the `ts`
+  field. The fixed `YYYY-MM-DDTHH:MM:SSZ` format guarantees that
+  string comparison yields the same ordering as datetime comparison.
+
+Filters compose: passing both narrows the result.
+
+`Journal.tail(n)` returns the last `n` valid events in file order
+(oldest first). The implementation is a linear scan; journals are
+expected to be small (the canonical consumer's journal is ~200 lines
+at the time of writing).
+
+---
+
+## 6. Exception hierarchy
+
+```
+JournalError
+├── JournalLockError    raised when an exclusive append lock cannot
+│                       be acquired (Windows retry exhaustion, etc.)
+└── JournalReadError    raised when the journal file cannot be
+                        opened for reading (permissions, etc.)
+```
+
+Catching `JournalError` covers all framework-raised failures.
+`ValueError` is used for caller-input violations (reserved-key
+collision, empty event name, negative `tail(n)`).
+
+---
+
+## 7. What this primitive does **not** own
+
+- Event-type catalogs (`worker_spawned`, `pr_merged`, …) — these are
+  org-specific and live in the consumer repo (e.g. a
+  `docs/journal-events.md` on the ja side).
+- Per-event field schemas — payload shape per event name is the
+  consumer's contract with itself.
+- Rotation, archival, or pruning policy — not in scope for 0.x.
+- Aggregation / dashboarding — readers (e.g. dashboard servers) live
+  in the consumer.
+
+---
+
+## 8. Surface summary
+
+| Symbol                                      | Status       | Where                |
+|---------------------------------------------|--------------|----------------------|
+| `Journal(path)`                             | experimental | Python               |
+| `Journal.append(event, **fields)`           | experimental | Python               |
+| `Journal.iter_events(filter_event, since)`  | experimental | Python               |
+| `Journal.tail(n)`                           | experimental | Python               |
+| `append_event(path, event, **fields)`       | experimental | Python (module-level)|
+| `iter_events(path, filter_event, since)`    | experimental | Python (module-level)|
+| `JournalError` / `JournalLockError` / `JournalReadError` | experimental | Python  |
+| `journal_append <path> <event> [k=v ...]`   | experimental | bash lib             |
+| `journal_append_raw <path>`                 | experimental | bash lib             |
+
+See [`api-surface-v0.x.md`](api-surface-v0.x.md) for the consolidated
+table.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "core-harness"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reusable safety primitives for Claude Code orchestrator harnesses"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -26,3 +26,4 @@ where = ["src"]
 [tool.setuptools.package-data]
 "core_harness.schema" = ["framework_schema.json"]
 "core_harness.hooks" = ["lib/*.sh"]
+"core_harness.audit" = ["lib/*.sh"]

--- a/src/core_harness/audit/__init__.py
+++ b/src/core_harness/audit/__init__.py
@@ -1,13 +1,244 @@
-"""Audit / journal protocol. 0.0.1 placeholder."""
+"""Audit / journal primitives — Step D (0.3.0).
 
-from typing import Any, Protocol, runtime_checkable
+Layer 1 framework slice for the append-only JSON-Lines audit journal.
+Owns:
+
+- The on-disk wire format (one JSON object per line, ``ts`` + ``event``
+  envelope, free payload thereafter).
+- Concurrent-write safety (``fcntl.flock`` on POSIX, ``msvcrt.locking``
+  on Windows).
+- Reader tolerance: blank lines and broken JSON are skipped with a
+  ``warnings.warn`` so retros / drift CI can still iterate.
+
+The framework deliberately knows **nothing** about which event types
+exist or which fields each event carries. The caller (the consumer
+runtime) owns the event-type catalog and per-event field conventions
+("Layer 1 owns the *how*, not the *what*").
+
+Path injection follows the Q4 one-way dependency rule: the journal
+file path is supplied by the consumer through the ``Journal``
+constructor; ``core_harness`` never reads ``CORE_HARNESS_JOURNAL_PATH``
+or any other consumer-shaped env var on its own.
+
+See ``docs/journal-contract.md`` for the full specification.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional
 
 
-@runtime_checkable
-class Journal(Protocol):
-    """Protocol for harness audit journals. Concrete shape TBD in 0.1+."""
+__all__ = [
+    "Journal",
+    "JournalError",
+    "JournalLockError",
+    "JournalReadError",
+    "append_event",
+    "iter_events",
+]
 
-    def record(self, *args: Any, **kwargs: Any) -> None: ...
+
+_RESERVED_KEYS = ("ts", "event")
 
 
-__all__ = ["Journal"]
+class JournalError(Exception):
+    """Base class for all :mod:`core_harness.audit` failures."""
+
+
+class JournalLockError(JournalError):
+    """Raised when an exclusive append lock cannot be acquired."""
+
+
+class JournalReadError(JournalError):
+    """Raised when the journal file cannot be opened for reading."""
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_PROCESS_LOCKS: "dict[str, threading.Lock]" = {}
+_PROCESS_LOCKS_GUARD = threading.Lock()
+
+
+def _process_lock_for(path: Path) -> threading.Lock:
+    key = str(path.resolve())
+    with _PROCESS_LOCKS_GUARD:
+        lock = _PROCESS_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _PROCESS_LOCKS[key] = lock
+        return lock
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _lock_exclusive(fd: int) -> None:
+        retries = 0
+        while True:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                retries += 1
+                if retries > 10:
+                    raise JournalLockError(
+                        "could not acquire exclusive lock on journal file"
+                    )
+
+    def _unlock(fd: int) -> None:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+
+else:
+    import fcntl
+
+    def _lock_exclusive(fd: int) -> None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError as exc:  # pragma: no cover — defensive
+            raise JournalLockError(str(exc)) from exc
+
+    def _unlock(fd: int) -> None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+
+def _encode_line(event: str, fields: Mapping[str, Any]) -> str:
+    for reserved in _RESERVED_KEYS:
+        if reserved in fields:
+            raise ValueError(
+                f"reserved key {reserved!r} cannot appear in fields"
+            )
+    payload = {"ts": _utcnow_iso(), "event": event}
+    payload.update(fields)
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def _append_raw(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    proc_lock = _process_lock_for(path)
+    with proc_lock:
+        fd = os.open(
+            str(path),
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+        try:
+            _lock_exclusive(fd)
+            try:
+                data = (line + "\n").encode("utf-8")
+                view = memoryview(data)
+                while view:
+                    written = os.write(fd, view)
+                    if written <= 0:  # pragma: no cover — defensive
+                        raise JournalError("short write to journal")
+                    view = view[written:]
+            finally:
+                _unlock(fd)
+        finally:
+            os.close(fd)
+
+
+class Journal:
+    """Append-only JSON-Lines journal with concurrent-write safety.
+
+    Each line is a JSON object with two reserved envelope keys:
+
+    * ``ts`` — ISO-8601 UTC (``YYYY-MM-DDTHH:MM:SSZ``), generated at
+      append time.
+    * ``event`` — caller-supplied event name (free-form string).
+
+    Caller-supplied ``fields`` may not collide with the reserved keys.
+    Readers skip blank lines and broken JSON with a :class:`UserWarning`.
+    Path injection follows the Q4 one-way dependency rule — the path is
+    supplied by the consumer.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def append(self, event, /, **fields: Any) -> None:
+        if not isinstance(event, str) or not event:
+            raise ValueError("event must be a non-empty string")
+        line = _encode_line(event, fields)
+        _append_raw(self.path, line)
+
+    def iter_events(
+        self,
+        filter_event: Optional[str] = None,
+        since: Optional[str] = None,
+    ) -> Iterator[dict]:
+        if not self.path.exists():
+            return
+        try:
+            handle = self.path.open("r", encoding="utf-8")
+        except OSError as exc:
+            raise JournalReadError(str(exc)) from exc
+        with handle as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                line = raw.rstrip("\n").rstrip("\r")
+                if not line.strip():
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    warnings.warn(
+                        f"skipping malformed journal line {lineno} in {self.path}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    continue
+                if not isinstance(obj, dict):
+                    warnings.warn(
+                        f"skipping non-object journal line {lineno} in {self.path}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    continue
+                if filter_event is not None and obj.get("event") != filter_event:
+                    continue
+                if since is not None:
+                    ts = obj.get("ts")
+                    if not isinstance(ts, str) or ts < since:
+                        continue
+                yield obj
+
+    def tail(self, n: int) -> "list[dict]":
+        if n < 0:
+            raise ValueError("n must be non-negative")
+        if n == 0:
+            return []
+        buf: "list[dict]" = []
+        for event in self.iter_events():
+            buf.append(event)
+            if len(buf) > n:
+                buf.pop(0)
+        return buf
+
+
+def append_event(path, event, /, **fields: Any) -> None:
+    """Convenience: ``Journal(path).append(event, **fields)``."""
+    Journal(path).append(event, **fields)
+
+
+def iter_events(
+    path: Path,
+    filter_event: Optional[str] = None,
+    since: Optional[str] = None,
+) -> Iterator[dict]:
+    """Convenience: ``Journal(path).iter_events(filter_event, since)``."""
+    return Journal(path).iter_events(filter_event=filter_event, since=since)

--- a/src/core_harness/audit/lib/journal_append.sh
+++ b/src/core_harness/audit/lib/journal_append.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# core_harness audit journal — bash companion library (Step D, 0.3.0).
+#
+# Layer 1 framework slice. Provides:
+#
+#   journal_append <path> <event> [k=v ...]
+#       Append one JSON line to <path>. ``ts`` (ISO-8601 UTC) and
+#       ``event`` are added automatically. Remaining args are treated as
+#       string-typed key=value fields. ``ts`` / ``event`` keys in the
+#       k=v list are rejected.
+#
+#   journal_append_raw <path>
+#       Read a single pre-encoded JSON line from stdin and append it.
+#       Caller is responsible for envelope correctness; this is the
+#       escape hatch for non-string field types.
+#
+# Concurrent-write safety: ``flock`` (util-linux) on systems where it is
+# available, falling back to "open in append mode and trust the kernel
+# for writes <= PIPE_BUF" otherwise. Consumers who need cross-platform
+# concurrency safety should prefer the Python ``Journal.append`` API.
+#
+# This library deliberately knows nothing about consumer-specific event
+# names or payload shapes. The journal file path is supplied by the
+# caller (Q4 one-way dependency).
+
+set -o pipefail
+
+# Sentinel so source-guards can detect the library is loaded.
+CORE_HARNESS_AUDIT_LIB_LOADED=1
+
+_journal_require_jq() {
+    if ! command -v jq >/dev/null 2>&1; then
+        printf 'core_harness.audit: jq is required for journal_append\n' >&2
+        return 127
+    fi
+}
+
+_journal_iso_utc_now() {
+    # ``date -u +%FT%TZ`` is portable across GNU coreutils, BSD/macOS
+    # date, and Git-for-Windows date. Output: ``YYYY-MM-DDTHH:MM:SSZ``.
+    date -u +%FT%TZ
+}
+
+_journal_write_locked() {
+    local path="$1"
+    local dir
+    dir="$(dirname -- "$path")"
+    [ -d "$dir" ] || mkdir -p -- "$dir"
+
+    if command -v flock >/dev/null 2>&1; then
+        # ``flock`` opens the file via fd 9 and serializes appends. We
+        # write the line via a here-string read by ``cat`` so the lock
+        # stays held until the write completes.
+        ( flock 9
+          cat >> "$path"
+        ) 9>>"$path"
+    else
+        # Best-effort: ``>>`` in POSIX shell is O_APPEND; concurrent
+        # writes <= PIPE_BUF are atomic on Linux. Cross-process safety
+        # without flock is not guaranteed — see module docstring.
+        cat >> "$path"
+    fi
+}
+
+# journal_append <path> <event> [k=v ...]
+journal_append() {
+    if [ "$#" -lt 2 ]; then
+        printf 'usage: journal_append <path> <event> [k=v ...]\n' >&2
+        return 2
+    fi
+    _journal_require_jq || return $?
+
+    local path="$1"; shift
+    local event="$1"; shift
+
+    if [ -z "$event" ]; then
+        printf 'core_harness.audit: event must be non-empty\n' >&2
+        return 2
+    fi
+
+    local ts
+    ts="$(_journal_iso_utc_now)"
+
+    # Build a jq invocation that produces ``{ts, event, ...fields}``.
+    # ``--arg`` binds string values safely, dodging shell-quoting bugs
+    # in caller-supplied payload values.
+    local -a jq_args=(-nc --arg ts "$ts" --arg event "$event")
+    local filter='{ts: $ts, event: $event}'
+
+    local pair key val
+    for pair in "$@"; do
+        case "$pair" in
+            *=*)
+                key="${pair%%=*}"
+                val="${pair#*=}"
+                ;;
+            *)
+                printf 'core_harness.audit: malformed field %q (want key=value)\n' "$pair" >&2
+                return 2
+                ;;
+        esac
+        if [ -z "$key" ]; then
+            printf 'core_harness.audit: empty field key in %q\n' "$pair" >&2
+            return 2
+        fi
+        case "$key" in
+            ts|event)
+                printf 'core_harness.audit: reserved key %q cannot appear in fields\n' "$key" >&2
+                return 2
+                ;;
+        esac
+        jq_args+=(--arg "$key" "$val")
+        filter="$filter + {\"$key\": \$$key}"
+    done
+
+    local line
+    if ! line="$(jq "${jq_args[@]}" "$filter")"; then
+        printf 'core_harness.audit: jq encoding failed\n' >&2
+        return 1
+    fi
+
+    printf '%s\n' "$line" | _journal_write_locked "$path"
+}
+
+# journal_append_raw <path>
+# Reads one JSON object (single line) from stdin and appends it verbatim.
+journal_append_raw() {
+    if [ "$#" -lt 1 ]; then
+        printf 'usage: journal_append_raw <path>\n' >&2
+        return 2
+    fi
+    local path="$1"
+    _journal_write_locked "$path"
+}

--- a/src/core_harness/audit/lib/journal_append.sh
+++ b/src/core_harness/audit/lib/journal_append.sh
@@ -103,12 +103,20 @@ journal_append() {
             printf 'core_harness.audit: empty field key in %q\n' "$pair" >&2
             return 2
         fi
+        # Restrict keys to an identifier-safe character set: keys are
+        # interpolated into the jq program as a literal object key and
+        # as a bound argument name, neither of which can be quoted at
+        # runtime. The Python API has no such restriction.
         case "$key" in
             ts|event)
                 printf 'core_harness.audit: reserved key %q cannot appear in fields\n' "$key" >&2
                 return 2
                 ;;
         esac
+        if ! [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            printf 'core_harness.audit: field key %q must match [A-Za-z_][A-Za-z0-9_]* (use Python API or journal_append_raw for arbitrary keys)\n' "$key" >&2
+            return 2
+        fi
         jq_args+=(--arg "$key" "$val")
         filter="$filter + {\"$key\": \$$key}"
     done
@@ -123,12 +131,34 @@ journal_append() {
 }
 
 # journal_append_raw <path>
-# Reads one JSON object (single line) from stdin and appends it verbatim.
+# Reads a single pre-encoded JSON object from stdin and appends it as
+# one JSONL line. Validates that the input parses as a JSON object and
+# emits exactly one trailing newline regardless of the input's framing.
 journal_append_raw() {
     if [ "$#" -lt 1 ]; then
         printf 'usage: journal_append_raw <path>\n' >&2
         return 2
     fi
+    _journal_require_jq || return $?
     local path="$1"
-    _journal_write_locked "$path"
+    local input
+    input="$(cat)"
+    # Reject empty input.
+    if [ -z "${input//[[:space:]]/}" ]; then
+        printf 'core_harness.audit: journal_append_raw requires non-empty stdin\n' >&2
+        return 2
+    fi
+    # Reject inputs that aren't a single JSON object.
+    if ! printf '%s' "$input" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf 'core_harness.audit: journal_append_raw input must be a single JSON object\n' >&2
+        return 2
+    fi
+    # Re-encode compactly to guarantee a single line, no embedded
+    # newlines, and a single trailing newline written by printf.
+    local line
+    if ! line="$(printf '%s' "$input" | jq -c '.')"; then
+        printf 'core_harness.audit: jq compact-encode failed\n' >&2
+        return 1
+    fi
+    printf '%s\n' "$line" | _journal_write_locked "$path"
 }

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,272 @@
+"""Tests for ``core_harness.audit`` — Step D / 0.3.0.
+
+No consumer-org fixtures: the audit module is a generic primitive, so
+tests use synthetic event names / payloads only.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import warnings
+from pathlib import Path
+
+import pytest
+
+from core_harness.audit import (
+    Journal,
+    JournalError,
+    JournalLockError,
+    JournalReadError,
+    append_event,
+    iter_events,
+)
+
+
+# ----------------------------------------------------------------------
+# Round-trip: append -> iter
+# ----------------------------------------------------------------------
+
+
+def test_append_then_iter_round_trip(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "journal.jsonl")
+    j.append("alpha", k=1, label="hello")
+    j.append("beta", payload={"nested": True})
+
+    events = list(j.iter_events())
+    assert len(events) == 2
+    assert events[0]["event"] == "alpha"
+    assert events[0]["k"] == 1
+    assert events[0]["label"] == "hello"
+    assert "ts" in events[0]
+    assert events[1]["event"] == "beta"
+    assert events[1]["payload"] == {"nested": True}
+
+
+def test_ts_format_is_iso_utc(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "journal.jsonl")
+    j.append("e")
+    [event] = list(j.iter_events())
+    ts = event["ts"]
+    # YYYY-MM-DDTHH:MM:SSZ
+    assert len(ts) == 20
+    assert ts.endswith("Z")
+    assert ts[4] == "-" and ts[7] == "-" and ts[10] == "T"
+
+
+def test_iter_on_missing_file_returns_empty(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "nope.jsonl")
+    assert list(j.iter_events()) == []
+
+
+def test_append_creates_parent_directory(tmp_path: Path) -> None:
+    target = tmp_path / "deeply" / "nested" / "journal.jsonl"
+    j = Journal(target)
+    j.append("x")
+    assert target.exists()
+
+
+# ----------------------------------------------------------------------
+# Reserved keys
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reserved", ["ts", "event"])
+def test_reserved_keys_rejected(tmp_path: Path, reserved: str) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    with pytest.raises(ValueError):
+        j.append("e", **{reserved: "nope"})
+
+
+def test_empty_event_rejected(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    with pytest.raises(ValueError):
+        j.append("")
+
+
+# ----------------------------------------------------------------------
+# tail
+# ----------------------------------------------------------------------
+
+
+def test_tail_returns_last_n(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    for i in range(5):
+        j.append("e", i=i)
+    last3 = j.tail(3)
+    assert [e["i"] for e in last3] == [2, 3, 4]
+
+
+def test_tail_zero_is_empty(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    j.append("e")
+    assert j.tail(0) == []
+
+
+def test_tail_more_than_total(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    j.append("e", i=0)
+    j.append("e", i=1)
+    assert [e["i"] for e in j.tail(10)] == [0, 1]
+
+
+def test_tail_negative_rejected(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    with pytest.raises(ValueError):
+        j.tail(-1)
+
+
+# ----------------------------------------------------------------------
+# Filters
+# ----------------------------------------------------------------------
+
+
+def test_iter_events_filter_by_event(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    j.append("alpha", i=1)
+    j.append("beta", i=2)
+    j.append("alpha", i=3)
+    alphas = list(j.iter_events(filter_event="alpha"))
+    assert [e["i"] for e in alphas] == [1, 3]
+
+
+def test_iter_events_since(tmp_path: Path) -> None:
+    path = tmp_path / "j.jsonl"
+    # Hand-craft lines so we control the timestamps.
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"ts": "2026-05-01T00:00:00Z", "event": "old"}),
+                json.dumps({"ts": "2026-05-02T12:00:00Z", "event": "mid"}),
+                json.dumps({"ts": "2026-05-03T00:00:00Z", "event": "new"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    j = Journal(path)
+    out = list(j.iter_events(since="2026-05-02T00:00:00Z"))
+    assert [e["event"] for e in out] == ["mid", "new"]
+
+
+def test_iter_events_filter_and_since_combined(tmp_path: Path) -> None:
+    path = tmp_path / "j.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"ts": "2026-05-01T00:00:00Z", "event": "alpha"}),
+                json.dumps({"ts": "2026-05-02T00:00:00Z", "event": "alpha"}),
+                json.dumps({"ts": "2026-05-02T00:00:00Z", "event": "beta"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = list(
+        Journal(path).iter_events(
+            filter_event="alpha", since="2026-05-02T00:00:00Z"
+        )
+    )
+    assert len(out) == 1
+    assert out[0]["event"] == "alpha"
+    assert out[0]["ts"] == "2026-05-02T00:00:00Z"
+
+
+# ----------------------------------------------------------------------
+# Reader tolerance: blank / malformed lines (the inventory's
+# "not-valid-json" contract).
+# ----------------------------------------------------------------------
+
+
+def test_iter_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
+    path = tmp_path / "j.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"ts": "2026-05-01T00:00:00Z", "event": "ok-1"}),
+                "",  # blank
+                "   ",  # whitespace-only
+                "not-valid-json",  # malformed
+                "[1,2,3]",  # JSON, but not an object
+                json.dumps({"ts": "2026-05-02T00:00:00Z", "event": "ok-2"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = list(Journal(path).iter_events())
+
+    assert [e["event"] for e in out] == ["ok-1", "ok-2"]
+    # At least one warning each for malformed JSON and non-object line.
+    messages = [str(w.message) for w in caught]
+    assert any("malformed" in m for m in messages)
+    assert any("non-object" in m for m in messages)
+
+
+# ----------------------------------------------------------------------
+# Concurrency: 100 threads all appending the same path round-trip.
+# ----------------------------------------------------------------------
+
+
+def test_concurrent_append_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "j.jsonl"
+    j = Journal(path)
+    n_threads = 20
+    per_thread = 5
+    barrier = threading.Barrier(n_threads)
+
+    def worker(tid: int) -> None:
+        barrier.wait()
+        for i in range(per_thread):
+            j.append("ping", tid=tid, i=i)
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    events = list(j.iter_events())
+    assert len(events) == n_threads * per_thread
+    seen = {(e["tid"], e["i"]) for e in events}
+    assert len(seen) == n_threads * per_thread
+
+    # Sanity: every line is well-formed JSON (no torn writes).
+    raw_lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(raw_lines) == n_threads * per_thread
+    for line in raw_lines:
+        json.loads(line)  # raises if torn
+
+
+# ----------------------------------------------------------------------
+# Module-level convenience wrappers.
+# ----------------------------------------------------------------------
+
+
+def test_module_level_append_and_iter(tmp_path: Path) -> None:
+    path = tmp_path / "j.jsonl"
+    append_event(path, "alpha", k=1)
+    append_event(path, "beta", k=2)
+    out = list(iter_events(path, filter_event="beta"))
+    assert len(out) == 1
+    assert out[0]["k"] == 2
+
+
+# ----------------------------------------------------------------------
+# Exception hierarchy.
+# ----------------------------------------------------------------------
+
+
+def test_exception_hierarchy() -> None:
+    assert issubclass(JournalLockError, JournalError)
+    assert issubclass(JournalReadError, JournalError)
+
+
+def test_unicode_payload_round_trip(tmp_path: Path) -> None:
+    j = Journal(tmp_path / "j.jsonl")
+    j.append("e", note="日本語テスト", emoji_off=True)
+    [event] = list(j.iter_events())
+    assert event["note"] == "日本語テスト"

--- a/tests/test_audit_bash.sh
+++ b/tests/test_audit_bash.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Bash-side tests for src/core_harness/audit/lib/journal_append.sh
+# (Step D / 0.3.0). Generic-only: no consumer-org event names.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_PATH="$SCRIPT_DIR/../src/core_harness/audit/lib/journal_append.sh"
+
+if [[ ! -f "$LIB_PATH" ]]; then
+  echo "FAIL: lib not found at $LIB_PATH" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; bash audit tests require jq" >&2
+  exit 0
+fi
+
+# shellcheck source=../src/core_harness/audit/lib/journal_append.sh
+source "$LIB_PATH"
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"; shift
+  if ( "$@" ) >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  ok   %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf '  FAIL %s\n' "$name" >&2
+    ( "$@" ) || true
+  fi
+}
+
+TMPDIR_AUDIT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_AUDIT"' EXIT
+
+# ----- basic round-trip -----------------------------------------------------
+
+t_basic_append_and_read() {
+    local path="$TMPDIR_AUDIT/basic.jsonl"
+    journal_append "$path" "ping" k=1 label=hello
+    [ -f "$path" ] || return 1
+    local line
+    line="$(cat "$path")"
+    # ts present, event=ping, k="1" (string-typed by --arg), label=hello
+    echo "$line" | jq -e '.event == "ping"' >/dev/null || return 1
+    echo "$line" | jq -e '.ts | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")' >/dev/null || return 1
+    echo "$line" | jq -e '.k == "1"' >/dev/null || return 1
+    echo "$line" | jq -e '.label == "hello"' >/dev/null || return 1
+}
+check "journal_append basic round-trip" t_basic_append_and_read
+
+# ----- JSON escaping: quotes / backslashes -------------------------------
+
+t_quotes_and_backslashes() {
+    local path="$TMPDIR_AUDIT/escape.jsonl"
+    journal_append "$path" "tricky" \
+        quoted='he said "hi"' \
+        backslash='a\b\c' \
+        mixed='line1
+line2'
+    local last
+    last="$(tail -n1 "$path")"
+    echo "$last" | jq -e '.quoted == "he said \"hi\""' >/dev/null || return 1
+    echo "$last" | jq -e '.backslash == "a\\b\\c"' >/dev/null || return 1
+    # newline embedded in value survives via --arg
+    echo "$last" | jq -e '.mixed | contains("line1\nline2")' >/dev/null || return 1
+}
+check "journal_append handles quotes / backslashes / newlines" t_quotes_and_backslashes
+
+# ----- reserved keys rejected ---------------------------------------------
+
+t_reserved_ts_rejected() {
+    local path="$TMPDIR_AUDIT/reserved.jsonl"
+    if journal_append "$path" "e" ts=2026-05-02T00:00:00Z 2>/dev/null; then
+        return 1
+    fi
+    # On rejection nothing should have been written.
+    [ ! -s "$path" ]
+}
+check "journal_append rejects reserved key ts" t_reserved_ts_rejected
+
+t_reserved_event_rejected() {
+    local path="$TMPDIR_AUDIT/reserved2.jsonl"
+    if journal_append "$path" "e" event=other 2>/dev/null; then
+        return 1
+    fi
+    [ ! -s "$path" ]
+}
+check "journal_append rejects reserved key event" t_reserved_event_rejected
+
+# ----- malformed field syntax -------------------------------------------
+
+t_missing_equals_rejected() {
+    local path="$TMPDIR_AUDIT/bad.jsonl"
+    if journal_append "$path" "e" no_equals 2>/dev/null; then
+        return 1
+    fi
+}
+check "journal_append rejects field without =" t_missing_equals_rejected
+
+# ----- missing args ----------------------------------------------------
+
+t_missing_args_rejected() {
+    if journal_append 2>/dev/null; then return 1; fi
+    if journal_append /tmp/x 2>/dev/null; then return 1; fi
+    return 0
+}
+check "journal_append rejects missing args" t_missing_args_rejected
+
+# ----- journal_append_raw -----------------------------------------------
+
+t_raw_append() {
+    local path="$TMPDIR_AUDIT/raw.jsonl"
+    echo '{"ts":"2026-05-02T00:00:00Z","event":"raw","x":42}' \
+        | journal_append_raw "$path"
+    local line
+    line="$(cat "$path")"
+    echo "$line" | jq -e '.event == "raw" and .x == 42' >/dev/null || return 1
+}
+check "journal_append_raw appends pre-encoded line" t_raw_append
+
+# ----- parent dir auto-create ------------------------------------------
+
+t_parent_dir_created() {
+    local path="$TMPDIR_AUDIT/deep/sub/path.jsonl"
+    journal_append "$path" "e" k=v
+    [ -f "$path" ]
+}
+check "journal_append creates parent directories" t_parent_dir_created
+
+# ----- multi-append accumulates ----------------------------------------
+
+t_multi_append() {
+    local path="$TMPDIR_AUDIT/multi.jsonl"
+    journal_append "$path" "e" i=1
+    journal_append "$path" "e" i=2
+    journal_append "$path" "e" i=3
+    local n
+    n="$(wc -l < "$path")"
+    [ "$n" -eq 3 ]
+}
+check "journal_append accumulates lines" t_multi_append
+
+# ----------------------------------------------------------------------
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test_audit_bash.sh
+++ b/tests/test_audit_bash.sh
@@ -103,6 +103,46 @@ t_missing_equals_rejected() {
 }
 check "journal_append rejects field without =" t_missing_equals_rejected
 
+t_unsafe_key_rejected() {
+    local path="$TMPDIR_AUDIT/unsafe.jsonl"
+    if journal_append "$path" "e" "weird-key=v" 2>/dev/null; then
+        return 1
+    fi
+    [ ! -s "$path" ]
+}
+check "journal_append rejects keys outside [A-Za-z_][A-Za-z0-9_]*" t_unsafe_key_rejected
+
+t_raw_rejects_non_object() {
+    local path="$TMPDIR_AUDIT/raw_bad.jsonl"
+    if echo '[1,2,3]' | journal_append_raw "$path" 2>/dev/null; then
+        return 1
+    fi
+    [ ! -s "$path" ]
+}
+check "journal_append_raw rejects non-object input" t_raw_rejects_non_object
+
+t_raw_rejects_empty() {
+    local path="$TMPDIR_AUDIT/raw_empty.jsonl"
+    if printf '' | journal_append_raw "$path" 2>/dev/null; then
+        return 1
+    fi
+}
+check "journal_append_raw rejects empty input" t_raw_rejects_empty
+
+t_raw_normalizes_framing() {
+    local path="$TMPDIR_AUDIT/raw_norm.jsonl"
+    # No trailing newline on input; should still produce exactly one
+    # line in the file.
+    printf '{"ts":"2026-05-02T00:00:00Z","event":"raw","x":1}' \
+        | journal_append_raw "$path"
+    printf '{"ts":"2026-05-02T00:00:01Z","event":"raw","x":2}' \
+        | journal_append_raw "$path"
+    local n
+    n="$(wc -l < "$path")"
+    [ "$n" -eq 2 ]
+}
+check "journal_append_raw normalizes single-line framing" t_raw_normalizes_framing
+
 # ----- missing args ----------------------------------------------------
 
 t_missing_args_rejected() {


### PR DESCRIPTION
Phase 3 Step D per [claude-org-ja#196 design](https://github.com/suisya-systems/claude-org-ja/blob/main/docs/design/core-harness-extraction.md) §4 + Q11 B ("core owns *how* to write/read; consumer owns *what*").

## Summary
- `core_harness.audit.Journal` (consumer-injected path; Q4 one-way)
  - `append(event, /, **fields)` — auto `ts` (ISO 8601 UTC); `ts` and `event` are reserved keys
  - `iter_events(filter_event=None, since=None)` — generator; blank / malformed / non-object lines skipped with `UserWarning`
  - `tail(n)` — last n events
  - module-level convenience: `append_event(path, event, /, **fields)`, `iter_events(path, ...)`
  - exceptions: `JournalError` ← `JournalLockError`, `JournalReadError`
  - concurrency: POSIX `fcntl.flock(LOCK_EX)` / Windows `msvcrt.locking()` + in-process `threading.Lock` keyed by absolute path
- bash `journal_append.sh` (shipped via package-data, resolved through `audit.lib_path()`):
  - `journal_append <path> <event> [k=v ...]` — `flock(1)` when available, keys validated as `[A-Za-z_][A-Za-z0-9_]*`, jq-driven JSON encoding
  - `journal_append_raw <path>` — stdin JSON, jq-validated as object, re-encoded compactly
- `docs/journal-contract.md` — wire format, locking semantics, reader tolerance
- `pyproject.toml` 0.2.0 → 0.3.0; `package-data` ships `audit/lib/*.sh`
- `docs/api-surface-v0.x.md` and `CHANGELOG.md` updated

## Layer 1 purity
No claude-org-specific names, paths, or events. `Journal(path)` requires the consumer to inject the path; the framework knows nothing about `.state/journal.jsonl`. Event-type catalog (worker_spawned, hook_blocked, etc.) is consumer-defined and stays in claude-org-ja.

## Tests
- Python: `pytest tests/` → **87 passed** (19 audit + 20 hooks + 37 validator + 11 generator)
- Bash audit: `bash tests/test_audit_bash.sh` → **PASS 13 / FAIL 0**
- Bash hooks: existing → PASS 22
- Concurrency: 20 threads × 5 appends all round-trip; no torn writes detected

## Codex self-review
1 round, 2 issues fixed in `1a4957a`:
1. bash key escape (jq program literal interpolation) → enforce `[A-Za-z_][A-Za-z0-9_]*` + re-encode
2. `journal_append_raw` framing (trailing newline / multi-line invariants) → jq object validation + compact re-encode

## Next (after merge)
- Tag `v0.3.0`
- claude-org-ja shim PR (`feat/step-d-shim`): pin v0.3.0, switch `tools/dispatcher_runner.py` Bash `>>` direct writes to `Journal.append()`, document event-type catalog in `docs/journal-events.md`, keep all 380+ existing tests green unmodified

## Refs
- Design: claude-org-ja#196 (merged)
- ja Issue: claude-org-ja#128
- Step C (preceding release): #2 (v0.2.0)