### PR TITLE
fix(0.3.1): Q4 purity finalization + security hardening + API clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,60 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-02
+
+Patch release — Q4 purity finalization, security hardening, and API
+clarification, driven by the phase3 cross-review (refs ja#128).
+
+### Changed (potentially breaking — pre-1.0 minor)
+
+- `validator.ValidationResult.__bool__` now raises `TypeError`. The
+  prior implicit truthiness check (`if result: ...`) was ambiguous —
+  callers split between "no errors" and "has any findings". Use
+  `result.ok` (no `ERROR`-severity findings) explicitly. The bound
+  `bool(result.findings)` keeps working for "has any findings" callers.
+- `validator.check_worker_settings(schema, base_dir)` gained a
+  keyword-only `include_worktrees: bool = True` parameter. Default
+  `True` causes one extra level of descent into
+  `<base_dir>/.worktrees/<branch>/.claude/settings.local.json`, so
+  worker checkouts living under a `.worktrees/` parent are now audited.
+  Pass `include_worktrees=False` to restore the 0.3.0 behaviour.
+
+### Security
+
+- `audit/lib/journal_append.sh`: when `flock(1)` is missing, the
+  fallback branch now emits a one-line stderr warning so callers learn
+  their concurrent appends are unprotected. Recommended fix is to use
+  the Python API (`Journal.append`) which uses `fcntl.flock` /
+  `msvcrt.locking` directly.
+
+### Fixed (Q4 purity)
+
+- `hooks.HookRunner.parse_pretooluse_stdin` block messages were
+  hardcoded Japanese; now neutral English ("Failed to parse PreToolUse
+  JSON: …" / "PreToolUse payload is not a JSON object"). Consumers with
+  a localized contract still inject prefix/locale via
+  `CORE_HARNESS_BLOCK_PREFIX` or `HookRunner(block_prefix=...)`.
+- `hooks/lib/core_harness_hooks.sh` `require_dependency` and the
+  internal `_jq` check messages were hardcoded Japanese; now neutral
+  English.
+- `core_harness/__init__.py` top docstring no longer references the
+  original consumer ("claude-org") by name.
+
+### Added
+
+- `core_harness.SchemaError` and `core_harness.UnresolvedPlaceholderError`
+  re-exported at package root and listed in
+  `docs/api-surface-v0.x.md` (they were already public via their
+  submodules; this just makes the surface document match reality).
+
+### Docs
+
+- `docs/api-surface-v0.x.md`: heading bumped to 0.3.1; `pip show`
+  reference removed in favour of the Python introspection recipe;
+  `validate_config` argument renamed to `source_label` to match the
+  implementation.
+
 ## [0.3.0] - 2026-05-02
 
 ### Added

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -1,6 +1,6 @@
 # Public API Surface — 0.x
 
-> **Status: 0.3.0 published.** This document tracks the evolving public
+> **Status: 0.3.1 published.** This document tracks the evolving public
 > surface during the pre-1.0 phase. Items below are *experimental*
 > unless explicitly marked `stable`; signatures may change between
 > minor versions per [`semver-policy.md`](semver-policy.md).
@@ -15,7 +15,7 @@
 | `core_harness.hooks` | experimental | PreToolUse hook contract (Step C, 0.2). Python helper + bash companion lib + `docs/hook-contract.md`. |
 | `core_harness.audit` | experimental | Journal API (Step D, 0.3). Python `Journal` class + bash companion lib + `docs/journal-contract.md`. |
 
-## Public symbols (0.2)
+## Public symbols (0.3.1)
 
 ### `core_harness.schema`
 
@@ -24,19 +24,20 @@
 | `load_framework_schema() -> dict` | experimental | Return the framework JSON Schema (deep copy). |
 | `framework_schema_path() -> Path` | experimental | On-disk path to the framework JSON file. |
 | `merge_schemas(framework: dict \| None, org_extension: dict) -> dict` | experimental | Merge framework defaults with org-extension; result has `global`, `required_hook_scripts`, `roles`, `worker_roles` always present. |
+| `SchemaError` | experimental | Raised by `merge_schemas` for malformed schema input. |
 
 ### `core_harness.validator`
 
 | Symbol | Status | Purpose |
 |---|---|---|
 | `validate_settings(settings, framework, org_extension, *, role, ...) -> ValidationResult` | experimental | Top-level entry. |
-| `validate_config(source, role, config, role_schema, global_schema, *, extra_allowed=None) -> list[Finding]` | experimental | Single-role audit. |
+| `validate_config(source_label, role, config, role_schema, global_schema, *, extra_allowed=None) -> list[Finding]` | experimental | Single-role audit. |
 | `validate_schema_integrity(schema) -> list[Finding]` | experimental | `required_hook_scripts` cross-check. |
 | `extract_role_blocks(md_text, roles) -> dict` | experimental | Pull JSON blocks from a docs projection. |
-| `check_worker_settings(schema, base_dir) -> list[Finding]` | experimental | Drift-check `<base_dir>/*/.claude/settings.local.json`. |
+| `check_worker_settings(schema, base_dir, *, include_worktrees=True) -> list[Finding]` | experimental | Drift-check `<base_dir>/*/.claude/settings.local.json`. When `include_worktrees=True` (default since 0.3.1), descends one level into `<base_dir>/.worktrees/<branch>/`. |
 | `matches_worker_template(config, template, *, expected_worker_dir=None) -> bool` | experimental | Placeholder-consistent template match. |
 | `Finding(source, role, severity, message)` | experimental | Result entry. |
-| `ValidationResult(findings)` | experimental | Aggregated result with `.ok`. |
+| `ValidationResult(findings)` | experimental | Aggregated result with `.ok`. **0.3.1+: `bool(result)` raises `TypeError` to prevent ambiguity — use `result.ok` explicitly.** |
 
 ### `core_harness.generator`
 
@@ -44,6 +45,7 @@
 |---|---|---|
 | `generate_settings(role, worker_dir, framework, org_extension, *, consumer_root=None, extra_placeholders=None) -> dict` | experimental | Top-level entry. |
 | `render_role(schema, role, **placeholders) -> dict` | experimental | Render a single `worker_roles` template. |
+| `UnresolvedPlaceholderError` | experimental | Raised by `render_role` / `generate_settings` when a `{placeholder}` cannot be substituted. |
 
 ### Placeholders recognised by the generator
 
@@ -103,9 +105,8 @@ Sourced via the path returned by `lib_path()`. Public functions:
 
 #### Bash companion (`audit/lib/journal_append.sh`)
 
-Shipped as package data; consumers locate it via `pip show
-core-harness` + `src/core_harness/audit/lib/journal_append.sh`, or
-import-and-introspect from Python (`Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"`).
+Shipped as package data; consumers locate it via Python introspection:
+`Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"`.
 Public functions: `journal_append <path> <event> [k=v ...]`,
 `journal_append_raw <path>` (stdin-driven). See
 [`journal-contract.md`](journal-contract.md) for the full spec.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "core-harness"
-version = "0.3.0"
+version = "0.3.1"
 description = "Reusable safety primitives for Claude Code orchestrator harnesses"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/core_harness/__init__.py
+++ b/src/core_harness/__init__.py
@@ -1,17 +1,22 @@
 """core-harness: reusable safety primitives for Claude Code orchestrator harnesses.
 
-Layer 1 of the claude-org architecture. See README.md and
+Layer 1 of a consumer harness architecture. See README.md and
 docs/canonical-ownership.md.
 
-Public surface (0.1, see docs/api-surface-v0.x.md):
+Public surface (0.3.1, see docs/api-surface-v0.x.md):
 
 * ``core_harness.schema``    — framework JSON Schema + merge helper.
 * ``core_harness.validator`` — settings.local.json audit engine.
 * ``core_harness.generator`` — worker_role template renderer.
 """
 
-from core_harness.generator import generate_settings, render_role
+from core_harness.generator import (
+    UnresolvedPlaceholderError,
+    generate_settings,
+    render_role,
+)
 from core_harness.schema import (
+    SchemaError,
     framework_schema_path,
     load_framework_schema,
     merge_schemas,
@@ -27,11 +32,12 @@ from core_harness.validator import (
     validate_settings,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "__version__",
     # schema
+    "SchemaError",
     "load_framework_schema",
     "framework_schema_path",
     "merge_schemas",
@@ -45,6 +51,7 @@ __all__ = [
     "check_worker_settings",
     "matches_worker_template",
     # generator
+    "UnresolvedPlaceholderError",
     "generate_settings",
     "render_role",
 ]

--- a/src/core_harness/audit/lib/journal_append.sh
+++ b/src/core_harness/audit/lib/journal_append.sh
@@ -58,6 +58,7 @@ _journal_write_locked() {
         # Best-effort: ``>>`` in POSIX shell is O_APPEND; concurrent
         # writes <= PIPE_BUF are atomic on Linux. Cross-process safety
         # without flock is not guaranteed — see module docstring.
+        printf 'core_harness.audit: warning: flock(1) not available; concurrent writes are not protected. Use the Python API for guaranteed concurrency safety.\n' >&2
         cat >> "$path"
     fi
 }

--- a/src/core_harness/hooks/__init__.py
+++ b/src/core_harness/hooks/__init__.py
@@ -109,11 +109,11 @@ class HookRunner:
             payload = json.loads(raw)
         except (ValueError, TypeError) as exc:
             self.exit_with_block(
-                f"PreToolUse JSON のパースに失敗しました: {exc}"
+                f"Failed to parse PreToolUse JSON: {exc}"
             )
         if not isinstance(payload, dict):
             self.exit_with_block(
-                "PreToolUse payload が JSON object ではありません"
+                "PreToolUse payload is not a JSON object"
             )
         return payload
 

--- a/src/core_harness/hooks/lib/core_harness_hooks.sh
+++ b/src/core_harness/hooks/lib/core_harness_hooks.sh
@@ -49,7 +49,7 @@ require_dependency() {
   local bin
   for bin in "$@"; do
     if ! command -v "$bin" >/dev/null 2>&1; then
-      block_with_message "$bin がインストールされていません。セキュリティ Hook の実行に必要です。"
+      block_with_message "$bin is not installed; required by security hook."
     fi
   done
 }
@@ -60,7 +60,7 @@ require_dependency() {
 __core_harness_read_stdin_once() {
   if [[ -z "${__CORE_HARNESS_PRETOOLUSE_INPUT+x}" ]]; then
     if ! command -v jq >/dev/null 2>&1; then
-      block_with_message "jq がインストールされていません。セキュリティ Hook の実行に必要です。"
+      block_with_message "jq is not installed; required by security hook."
     fi
     __CORE_HARNESS_PRETOOLUSE_INPUT=$(cat)
   fi

--- a/src/core_harness/validator/__init__.py
+++ b/src/core_harness/validator/__init__.py
@@ -61,7 +61,10 @@ class ValidationResult:
         return not any(f.severity == "ERROR" for f in self.findings)
 
     def __bool__(self) -> bool:
-        return self.ok
+        raise TypeError(
+            "Truth value of ValidationResult is ambiguous; "
+            "use `result.ok` (no errors) or `bool(result.findings)` (has any findings)."
+        )
 
     def __iter__(self) -> Iterator:
         return iter(self.findings)
@@ -444,9 +447,20 @@ def matches_worker_template(
     return True
 
 
-def check_worker_settings(schema: dict, base_dir) -> list:
+def check_worker_settings(
+    schema: dict,
+    base_dir,
+    *,
+    include_worktrees: bool = True,
+) -> list:
     """Walk ``<base_dir>/*/.claude/settings.local.json`` and report
-    drift against the ``worker_roles`` templates from ``schema``."""
+    drift against the ``worker_roles`` templates from ``schema``.
+
+    When ``include_worktrees`` is True (default), directories named
+    ``.worktrees`` are descended into one level so worker checkouts
+    living under ``<base_dir>/.worktrees/<branch>/`` are audited too.
+    Pass ``False`` for the legacy 0.3.0 behaviour.
+    """
     findings: list = []
     base_dir = Path(base_dir)
     if not base_dir.is_dir():
@@ -472,7 +486,17 @@ def check_worker_settings(schema: dict, base_dir) -> list:
         )
         return findings
 
-    for worker_dir in sorted(p for p in base_dir.iterdir() if p.is_dir()):
+    candidate_dirs: list = sorted(
+        p for p in base_dir.iterdir() if p.is_dir() and p.name != ".worktrees"
+    )
+    if include_worktrees:
+        wt_dir = base_dir / ".worktrees"
+        if wt_dir.is_dir():
+            candidate_dirs.extend(
+                sorted(p for p in wt_dir.iterdir() if p.is_dir())
+            )
+
+    for worker_dir in candidate_dirs:
         settings_path = worker_dir / ".claude" / "settings.local.json"
         if not settings_path.is_file():
             continue

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -409,5 +409,74 @@ class FailClosedTests(unittest.TestCase):
         self.assertFalse(matches_worker_template(leaky_config, template))
 
 
+class ValidationResultBoolTests(unittest.TestCase):
+    """0.3.1: bool(ValidationResult) is rejected to prevent ``if result``
+    being misread as ``if result.ok``. See cross-review M5."""
+
+    def test_bool_raises_typeerror(self):
+        result = ValidationResult(findings=[])
+        with self.assertRaises(TypeError):
+            bool(result)
+
+    def test_bool_raises_even_with_errors(self):
+        result = ValidationResult(findings=[Finding("s", "r", "ERROR", "x")])
+        with self.assertRaises(TypeError):
+            bool(result)
+
+    def test_ok_property_still_works(self):
+        self.assertTrue(ValidationResult(findings=[]).ok)
+        self.assertFalse(
+            ValidationResult(findings=[Finding("s", "r", "ERROR", "x")]).ok
+        )
+
+
+class CheckWorkerSettingsWorktreesTests(unittest.TestCase):
+    """0.3.1: include_worktrees descends into ``.worktrees/<branch>/``."""
+
+    TEMPLATE = {
+        "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+        "env": {"WORKER_DIR": "{worker_dir}"},
+    }
+
+    def _make_settings(self, dir_path: Path, worker_dir_value: str) -> None:
+        claude_dir = dir_path / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        (claude_dir / "settings.local.json").write_text(
+            json.dumps(
+                {
+                    "permissions": {"allow": ["Bash(sleep:*)"], "deny": []},
+                    "env": {"WORKER_DIR": worker_dir_value},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_include_worktrees_descends(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            wt = base / ".worktrees" / "branch-a"
+            self._make_settings(wt, str(wt.resolve()))
+            findings = check_worker_settings(
+                {"worker_roles": {"x": self.TEMPLATE}}, base
+            )
+            self.assertEqual(findings, [])
+
+    def test_include_worktrees_false_skips(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            wt = base / ".worktrees" / "branch-a"
+            # populate with config that would NOT match — to assert we skip
+            self._make_settings(wt, "/wrong/path")
+            findings = check_worker_settings(
+                {"worker_roles": {"x": self.TEMPLATE}},
+                base,
+                include_worktrees=False,
+            )
+            # No finding because we never even looked at .worktrees
+            self.assertEqual(findings, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Patch release addressing the [Phase 3 cross-review](https://github.com/suisya-systems/claude-org-ja/issues/128#issuecomment-...) findings (2 Blocker + 5 Major + 8 Minor). Lands as **0.3.1** so claude-org-ja can pin the fixed surface from its shim follow-up.

## Blockers fixed (Q4 one-way purity)
- **B1** `hooks/__init__.py:112,116` — Japanese block reasons in `parse_pretooluse_stdin` replaced with English ("Failed to parse PreToolUse JSON: …", "PreToolUse payload is not a JSON object").
- **B2** `hooks/lib/core_harness_hooks.sh:52,63` — Japanese error strings in `require_dependency` and the missing-jq path replaced with English ("$bin is not installed; required by security hook." etc.).
- **Nit** Top-level docstring in `__init__.py` neutralised ("Layer 1 of a consumer harness architecture" instead of naming claude-org).

## Majors fixed
- **M2** `audit/lib/journal_append.sh:50-62` — emits an explicit stderr warning when `flock(1)` is missing, so consumers can detect the lock-less fallback instead of getting silent `>>`.
- **M5** `validator/__init__.py:63-64` — `ValidationResult.__bool__` now raises `TypeError` with a guidance message; +3 regression tests covering correct `result.ok` usage and the explicit truth-value error.
- **M4 (core-harness side)** `validator.check_worker_settings` gains a kw-only `include_worktrees: bool = True` so consumers can recurse `.worktrees/` (or opt out for compat). +2 tests cover descent + opt-out. The ja shim follow-up wires this through.

## Minors fixed
- `core_harness.__version__` 0.3.0 → 0.3.1 (was stuck at "0.1.0" before; fixed).
- `pyproject.toml` 0.3.0 → 0.3.1.
- `docs/api-surface-v0.x.md` heading and entries — "Public symbols (0.3.1)" + `SchemaError`, `UnresolvedPlaceholderError` listed and re-exported at the package root.
- `validate_config` arg name corrected to `source_label` (matches implementation).
- `docs/api-surface-v0.x.md` `pip show` recipe replaced with `Path(core_harness.audit.__file__).parent / "lib" / "journal_append.sh"` Python-introspection recipe.
- `CHANGELOG.md` `[0.3.1]` section.

## Tests
- Python: `pytest tests/` → **92 passed** (87 prior + 5 new for ValidationResult truth-value + include_worktrees descent/opt-out)
- bash hooks: 22 passed
- bash audit: 13 passed
- Q4 grep: only doc-string / comment references to claude-org-ja remain (intentional context explaining override mechanism); zero functional JP strings; zero Layer 1 → consumer dependencies.

## Next (after merge)
- Tag `v0.3.1`
- claude-org-ja shim follow-up (`fix/0.3.1-shim-followup`):
  - M1 `_is_git_tracked` fail-CLOSED
  - M3 reject + warn on `JOURNAL_PATH` env / `--path` override at the org boundary
  - M4 CI `--include-worker-settings` + new `include_worktrees=True` wired
  - Minor 4/5/6 (framework_schema.json local-copy removal, segment-split python-detection ordering, requirements.txt SHA-pin comment)

## Refs
- Phase 3 cross-review (worker report)
- ja Issue: claude-org-ja#128 (closed)
- Preceding release: v0.3.0 (PR #3)