### PR TITLE
chore: 1.0 prep — CI matrix, PyPI release skeleton, doc-comment neutralisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 *.md text eol=lf
 *.json text eol=lf
 *.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build distributions
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI (Trusted Publisher / OIDC)
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/core-harness
+    permissions:
+      id-token: write  # required for PyPI Trusted Publisher (OIDC)
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish (OIDC)
+        # Requires a one-time setup on PyPI: register this repo / workflow /
+        # environment as a Trusted Publisher for the `core-harness` project
+        # (https://docs.pypi.org/trusted-publishers/). No API token needed.
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      # Alternative — API-token method (kept as a fallback). To use, comment
+      # out the OIDC step above, drop the `id-token: write` permission, and
+      # uncomment the block below after adding `PYPI_API_TOKEN` to repo
+      # secrets.
+      #
+      # - name: Publish (API token)
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
+
+  github-release:
+    name: Attach artifacts to GitHub Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create / update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF##*/}"
+          gh release view "$tag" >/dev/null 2>&1 \
+            && gh release upload "$tag" dist/* --clobber \
+            || gh release create "$tag" dist/* \
+                 --title "$tag" \
+                 --notes "Automated release for $tag. See CHANGELOG.md."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,53 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.os }} / py${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest
+      - name: Run pytest
+        run: python -m pytest tests/ -v
+
+  bash-tests:
+    name: bash tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+      - name: Install jq (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jq
+      - name: Run hooks bash tests
+        run: bash tests/test_hooks_bash.sh
+      - name: Run audit bash tests
+        run: bash tests/test_audit_bash.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ## [Unreleased]
 
+Internal — 1.0 transition prep (no public API changes).
+
+### Added
+
+- `.github/workflows/tests.yml` — CI matrix running pytest on
+  `{ubuntu-latest, macos-latest, windows-latest}` × `{3.10, 3.11, 3.12}`,
+  plus a separate job that runs `tests/test_hooks_bash.sh` and
+  `tests/test_audit_bash.sh` on Linux and macOS.
+- `.github/workflows/release.yml` — skeleton release pipeline. On
+  `v*` tag push: build sdist + wheel, publish to PyPI via
+  Trusted Publisher (OIDC, no token needed), and attach the artefacts
+  to a GitHub Release. The Trusted Publisher entry on PyPI is a
+  one-time manual setup; an API-token alternative is left commented in
+  the workflow for fallback.
+- `README.md` — new "Releasing" section documenting the tag-driven
+  flow and the PyPI Trusted Publisher prerequisite. Tests CI badge
+  added at the top.
+
+### Changed (internal — doc-comment neutralisation)
+
+- Removed lingering `claude-org-ja` / role-name references (`secretary`,
+  `dispatcher`, `curator`) from Layer-1 source docstrings, the bash
+  hook library comment, `docs/api-surface-v0.x.md`,
+  `docs/canonical-ownership.md`, and `docs/hook-contract.md`. Examples
+  that previously named a specific consumer now use generic
+  "consumer harness" / locale-illustration phrasing. No public API,
+  config key, or shipped string changed.
+
 ## [0.3.1] - 2026-05-02
 
 Patch release — Q4 purity finalization, security hardening, and API

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # core-harness
 
+[![tests](https://github.com/suisya-systems/core-harness/actions/workflows/tests.yml/badge.svg)](https://github.com/suisya-systems/core-harness/actions/workflows/tests.yml)
+
 Reusable safety primitives for Claude Code orchestrator harnesses (permission schema, hook framework, audit/journal).
 
 > **Status: pre-1.0, API not frozen.** Latest release: **v0.3.1**. Expect breaking changes between minor versions until 1.0. See [`docs/semver-policy.md`](docs/semver-policy.md).
@@ -154,6 +156,49 @@ Pre-1.0 semver (see [`docs/semver-policy.md`](docs/semver-policy.md)):
 2. Two consecutive minor releases shipped with no breaking changes.
 3. The public surface in `docs/api-surface-v0.x.md` marked stable (no
    remaining `experimental:` entries for items intended for 1.0).
+
+## Releasing
+
+Releases are tag-driven. Pushing a tag matching `v*` triggers
+[`.github/workflows/release.yml`](.github/workflows/release.yml),
+which:
+
+1. Builds an sdist and a wheel via `python -m build`.
+2. Publishes the artefacts to PyPI through a
+   [Trusted Publisher](https://docs.pypi.org/trusted-publishers/)
+   (OIDC — no API token is stored in the repo).
+3. Creates / updates a GitHub Release with the same tag and attaches
+   the built artefacts.
+
+Cutting a release:
+
+```bash
+# 1. Bump version in pyproject.toml and update CHANGELOG.md.
+# 2. Land both via PR.
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+**One-time setup before the first PyPI publish.** PyPI must have a
+Trusted Publisher entry registered for this repo. On
+[pypi.org/manage/project/core-harness/settings/publishing/](https://pypi.org/manage/project/core-harness/settings/publishing/),
+add a publisher with:
+
+- Owner: `suisya-systems`
+- Repository: `core-harness`
+- Workflow: `release.yml`
+- Environment: `pypi`
+
+Until that entry exists, the publish step in `release.yml` will fail.
+The build and GitHub-Release jobs still succeed independently, so
+re-tagging after the entry is registered is enough to publish.
+
+If Trusted Publisher is not desired, the workflow has an API-token
+fallback commented out — uncomment it, drop the `id-token: write`
+permission, and add `PYPI_API_TOKEN` to repo secrets.
+
+PyPI publishing remains deferred until the 1.0 cut; the workflow
+landing here is the skeleton, not a release.
 
 ## Related
 

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -135,8 +135,11 @@ See [`semver-policy.md`](semver-policy.md). In short:
   (`.github/workflows/release.yml`, OIDC / Trusted Publisher).
   PyPI-side Trusted Publisher entry is not yet registered; first
   `v*` tag will only publish once that one-time setup is done.
-- **Doc-comment neutralisation**: complete — no `claude-org` / role-name
-  references remain in `src/` or `docs/`.
+- **Doc-comment neutralisation**: complete — Layer-1 source docstrings,
+  the bash hook library comment, and the canonical / hook / surface
+  contract docs no longer name a specific consuming repo or specific
+  role names. Architecture / "Related" links in `README.md` are kept
+  as deliberate project-history context.
 - **External-consumer count / consecutive-minor count**: still
   pre-1.0 as of v0.3.1; tracked in `semver-policy.md`.
 

--- a/docs/api-surface-v0.x.md
+++ b/docs/api-surface-v0.x.md
@@ -50,11 +50,10 @@
 ### Placeholders recognised by the generator
 
 - `{worker_dir}` — absolute path to the worker's worktree.
-- `{consumer_root}` — absolute path to the consuming repo (org-neutral
-  rename of the legacy `{claude_org_path}`).
-- Arbitrary names supplied via `extra_placeholders={...}` for legacy
-  alias support (e.g. consumers may pass `{claude_org_path}` pointing
-  at the same value as `consumer_root`).
+- `{consumer_root}` — absolute path to the consuming repo.
+- Arbitrary names supplied via `extra_placeholders={...}` for
+  consumer-specific alias support (consumers may register additional
+  placeholder names that point at the same value as `consumer_root`).
 
 ### `core_harness.hooks`
 
@@ -85,8 +84,8 @@ Sourced via the path returned by `lib_path()`. Public functions:
 
 - `CORE_HARNESS_BLOCK_PREFIX` — overrides the default `"Blocked: "`
   prefix in both the Python helper and the bash companion. Consumers
-  with a locale-specific contract (e.g. claude-org-ja's
-  `"ブロック: "`) export this at their org boundary so Layer 1 stays
+  with a locale-specific contract (for example a localized prefix such
+  as `"ブロック: "`) export this at their org boundary so Layer 1 stays
   unaware of consumer locale.
 
 ### `core_harness.audit`
@@ -126,6 +125,20 @@ See [`semver-policy.md`](semver-policy.md). In short:
 - ≥ 2 consecutive minor releases with no breaking changes.
 - All entries above marked `stable`; no remaining `placeholder` /
   `experimental` for items intended for 1.0.
+
+### 1.0 transition gates — current state
+
+- **CI matrix**: landed (`.github/workflows/tests.yml`) — pytest on
+  Linux / macOS / Windows × Python 3.10–3.12, plus bash hook + audit
+  tests on Linux / macOS.
+- **PyPI publishing pipeline**: skeleton landed
+  (`.github/workflows/release.yml`, OIDC / Trusted Publisher).
+  PyPI-side Trusted Publisher entry is not yet registered; first
+  `v*` tag will only publish once that one-time setup is done.
+- **Doc-comment neutralisation**: complete — no `claude-org` / role-name
+  references remain in `src/` or `docs/`.
+- **External-consumer count / consecutive-minor count**: still
+  pre-1.0 as of v0.3.1; tracked in `semver-policy.md`.
 
 ## Conventions used in this document
 

--- a/docs/canonical-ownership.md
+++ b/docs/canonical-ownership.md
@@ -1,7 +1,8 @@
 # Canonical Ownership & One-Way Dependency
 
-`core-harness` is **Layer 1** of the claude-org architecture. It owns the
-generic framework primitives that every orchestrator harness needs:
+`core-harness` is **Layer 1** of the orchestrator-harness architecture.
+It owns the generic framework primitives that every orchestrator
+harness needs:
 
 - Permission schema type definitions (e.g. `forbidden_allow_*`,
   `required_hook_scripts`)
@@ -13,15 +14,15 @@ generic framework primitives that every orchestrator harness needs:
 ## Dependency direction (one-way)
 
 ```
-claude-org-ja  ─depends on─►  core-harness
-core-harness   ──does NOT──►  claude-org-ja
+consumer harness  ─depends on─►  core-harness
+core-harness      ──does NOT──►  any consumer
 ```
 
 `core-harness` **must not** import from, name, or otherwise know about any
 consuming layer. In particular, `core-harness` does not contain:
 
-- Role names (secretary, dispatcher, curator, worker, ...) — these are
-  org-specific concepts and stay in the consuming layer.
+- Role names — any specific role catalogue is an org-specific concept
+  and stays in the consuming layer.
 - Specific worker rosters, naming schemes, or routing rules.
 - Any string or constant scoped to a particular org's deployment.
 

--- a/docs/hook-contract.md
+++ b/docs/hook-contract.md
@@ -43,8 +43,8 @@ The deny-reason line follows the format:
 
 where `{block_prefix}` defaults to the neutral English `"Blocked: "`.
 Layer 1 ships no consumer-specific locale string. Consumers that need a
-different prefix (for example claude-org-ja's legacy `"ブロック: "`
-contract used by 380+ existing hook tests) inject it per process via
+different prefix (for example a localized contract such as
+`"ブロック: "`) inject it per process via
 the `CORE_HARNESS_BLOCK_PREFIX` environment variable, or per-call via
 `HookRunner(block_prefix=...)` in Python /
 `CORE_HARNESS_BLOCK_PREFIX=...` exported before sourcing
@@ -141,17 +141,16 @@ can call several without re-reading stdin.
 - Any specific deny rule (no `--no-verify` blocker, no `git push`
   blocker, no path-based file boundary). Those live in the consumer
   repo, which composes the framework helpers with its own policy.
-- Any role catalogue (no `secretary`, `dispatcher`, `worker`).
+- Any role catalogue (no consumer-specific role names).
 - Path-normalisation helpers tied to the consumer's directory layout —
   consumers ship those alongside their org-specific hooks.
 
 ## 5. Consumer-specific localisation
 
 Layer 1 (`core-harness`) ships only the neutral English default
-`"Blocked: "`. Consumers with a localised contract — for example
-claude-org-ja's legacy `"ブロック: "` deny-line, used by an existing
-380+ hook test suite — inject their prefix at the org boundary, never
-inside `core-harness`:
+`"Blocked: "`. Consumers with a localised contract — for example a
+legacy localized deny-line such as `"ブロック: "` — inject their prefix
+at the org boundary, never inside `core-harness`:
 
 - **Python** consumers: instantiate `HookRunner(block_prefix="ブロック: ")`,
   or set `CORE_HARNESS_BLOCK_PREFIX` once at process start.

--- a/src/core_harness/generator/__init__.py
+++ b/src/core_harness/generator/__init__.py
@@ -2,8 +2,9 @@
 
 Renders a concrete ``settings.local.json`` payload from a worker_roles
 template by substituting placeholders such as ``{worker_dir}`` and
-``{consumer_root}`` (the org-neutral name; the consumer's previous
-``{claude_org_path}`` is supported as an alias).
+``{consumer_root}``. Consumers that historically used a different
+placeholder name can register it as an alias of ``consumer_root`` via
+``extra_placeholders``.
 
 Public surface (0.1):
 
@@ -120,9 +121,8 @@ def generate_settings(
     Merges ``framework_schema`` with ``org_extension_schema``, locates
     ``worker_roles[role]`` in the merged dict, and renders it with
     ``{worker_dir}`` / ``{consumer_root}`` substituted. ``extra_placeholders``
-    lets the caller supply additional org-specific aliases (e.g.
-    ``{claude_org_path}``) that point at the same value as
-    ``consumer_root``.
+    lets the caller supply additional consumer-specific aliases that
+    point at the same value as ``consumer_root``.
     """
     merged = merge_schemas(framework_schema, org_extension_schema)
     placeholders: dict = {"worker_dir": worker_dir}

--- a/src/core_harness/hooks/__init__.py
+++ b/src/core_harness/hooks/__init__.py
@@ -13,8 +13,8 @@ Layer 1 framework slice for PreToolUse hook wiring. Owns:
 The framework deliberately knows **nothing** about consumer-specific
 concepts: no role names, no path patterns, no consumer-locale string
 constants. The default block-message prefix is the neutral English
-``"Blocked: "``; consumers that need a different prefix (e.g.
-claude-org-ja's ``"ブロック: "`` contract) inject it via the
+``"Blocked: "``; consumers that need a different prefix (for example a
+localized contract such as ``"ブロック: "``) inject it via the
 ``CORE_HARNESS_BLOCK_PREFIX`` environment variable or
 ``HookRunner(block_prefix=...)`` argument. Layer 1 stays unaware of
 any specific consumer.
@@ -34,8 +34,8 @@ DEFAULT_BLOCK_PREFIX = "Blocked: "
 """Default block-message prefix.
 
 Layer-1-neutral English; consumers with org-specific localisation
-(e.g. claude-org-ja's legacy ``"ブロック: "`` contract) override this
-per-process via ``CORE_HARNESS_BLOCK_PREFIX`` or per-runner via
+(for example a legacy localized contract like ``"ブロック: "``) override
+this per-process via ``CORE_HARNESS_BLOCK_PREFIX`` or per-runner via
 ``HookRunner(block_prefix=...)``. The framework intentionally does not
 ship any consumer-specific string as a default.
 """

--- a/src/core_harness/hooks/lib/core_harness_hooks.sh
+++ b/src/core_harness/hooks/lib/core_harness_hooks.sh
@@ -88,10 +88,10 @@ read_pretooluse_tool_name() {
 }
 
 # ---------------------------------------------------------------------------
-# Generic Bash command-string parser. Originally claude-org-ja's
-# `.hooks/lib/segment-split.sh` — moved here as the framework slice
+# Generic Bash command-string parser. Lives in the framework slice
 # because nothing in these helpers is consumer-specific (no role names,
-# no path patterns). Bug fixes propagate to all consumers.
+# no path patterns). Bug fixes propagate to all consumers that source
+# this library.
 # ---------------------------------------------------------------------------
 
 # split_segments


### PR DESCRIPTION
## Summary
- Add `.github/workflows/tests.yml`: pytest on Linux/macOS/Windows × Python 3.10-3.12, plus bash hook + audit tests on Linux/macOS.
- Add `.github/workflows/release.yml`: tag-driven build (sdist+wheel) + PyPI publish via Trusted Publisher (OIDC). API-token fallback left commented.
- Neutralise lingering `claude-org-ja` / role-name references in `src/` and `docs/` (Layer-1 source docstrings, bash hook library comment, canonical-ownership / hook-contract / api-surface docs). README architecture & Related links are intentionally kept as project-history context.
- README: tests CI badge + new "Releasing" section documenting the Trusted Publisher setup.
- CHANGELOG `[Unreleased]` opened with the above (internal-only; no public API change).
- `docs/api-surface-v0.x.md`: add "1.0 transition gates — current state".

No public API surface changed; this is internal 1.0 prep.

## Test plan
- [x] `python -m pytest tests/ -v` — 92 passed (local)
- [x] `bash tests/test_hooks_bash.sh` — 22/22 (local)
- [x] `bash tests/test_audit_bash.sh` — 13/13 (local)
- [ ] CI tests.yml green on PR (matrix x9 + 2 bash jobs)
- [ ] After merge: register PyPI Trusted Publisher (Owner: `suisya-systems`, Repo: `core-harness`, Workflow: `release.yml`, Env: `pypi`). First `v*` tag will then publish; until then publish step will fail by design.

Refs claude-org-ja#128 (extraction tracking, closed); design PR ja#196 §7.