### PR TITLE
chore(readme): clarify scope as Claude Code governance primitives, not generic agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Reusable safety primitives for Claude Code orchestrator harnesses (permission sc
 
 > **Status: pre-1.0, API not frozen.** Latest release: **v0.3.1**. Expect breaking changes between minor versions until 1.0. See [`docs/semver-policy.md`](docs/semver-policy.md).
 
+> **Not an AI agent framework.** `core-harness` provides Claude Code-specific
+> governance primitives (permission schema, hook framework, audit/journal). It
+> does not implement agent runtime abstractions such as `agent` / `tool` /
+> `run` / `state` / `handoff` / `memory` / `trace` — those concerns belong in
+> higher layers (e.g. consumer harnesses like `claude-org-ja`) or in dedicated
+> agent frameworks (LangChain, AutoGen, CrewAI, OpenAI Agents SDK).
+
 ## Overview
 
 `core-harness` is **Layer 1** of the [claude-org] 4-layer architecture:


### PR DESCRIPTION
Adds an explicit positioning paragraph to the README so readers don't mistake `core-harness` for a generic AI agent framework on the level of LangChain / AutoGen / CrewAI / OpenAI Agents SDK.

## Background
A frank evaluation by an external Codex review (using web-grounded comparisons against the four major agent frameworks above) flagged that the existing tagline "Reusable safety primitives for Claude Code orchestrator harnesses" is technically accurate but invites readers to expect agent-runtime abstractions (`agent` / `tool` / `run` / `state` / `handoff` / `memory` / `trace`) that are explicitly out of scope for Layer 1.

## Change
1-paragraph clarification added near the top of `README.md`, stating that core-harness is **not** an agent framework — agent runtime concerns belong to higher layers (e.g. org-runtime / consumer harnesses) or dedicated agent frameworks. The existing tagline stays.

## No code changes
README only.

## Refs
- Codex strategic evaluation (frank-eval, recorded in claude-org-ja#128 retrospective)
- design Q4 (one-way dependency, Layer 1 = governance primitives)
- canonical-ownership.md (Layer 1 scope)