### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to pre-1.0 semantic versioning as defined in
 
 ## [Unreleased]
 
-Internal — 1.0 transition prep (no public API changes).
+## [0.3.2] - 2026-05-02
+
+Maintenance release — first publish via PyPI Trusted Publisher (OIDC).
+No public API changes; bundles the 1.0 transition prep that landed on
+`main` after 0.3.1 (CI matrix, release workflow skeleton, README scope
+clarification, and doc-comment neutralisation).
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "core-harness"
-version = "0.3.1"
+version = "0.3.2"
 description = "Reusable safety primitives for Claude Code orchestrator harnesses"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2 in pyproject.toml
- Convert Unreleased CHANGELOG section to [0.3.2] - 2026-05-02
- Maintenance release to trigger first PyPI publish via Trusted Publisher

No code changes since v0.3.1; the diff comprises CI matrix (#6), README scope clarification (#5/#8), and doc-comment neutralisation only.

## Test plan
- [x] pyproject.toml version parses cleanly
- [ ] CI green
- [ ] After merge, tag v0.3.2 fires release.yml and PyPI publishes 0.3.2