### PR TITLE
ci: bump deprecated Node.js 20 actions to Node 24 compatible versions (#10)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install build
@@ -20,7 +20,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -36,7 +36,7 @@ jobs:
       id-token: write  # required for PyPI Trusted Publisher (OIDC)
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -63,9 +63,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install
@@ -36,8 +36,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install


### PR DESCRIPTION
## Summary
GitHub Actions will switch the default Node runtime from Node 20 to Node 24 on
2026-06-02 and remove Node 20 entirely on 2026-09-16. This PR bumps the four
affected actions to the first major release whose `action.yml` actually
declares `using: node24` (verified against each tag's raw `action.yml`):

- `actions/checkout`: v4 → v5 — v5.0.0 switched the runner to `node24`.
- `actions/setup-python`: v5 → v6 — v6.0.0 switched the runner to `node24`.
- `actions/upload-artifact`: v4 → **v6** — v5.0.0's release notes mention
  Node 24 support, but the published `action.yml` still pins `node20`.
  v6.0.0 is the first tag actually running on `node24`.
- `actions/download-artifact`: v4 → **v7** — v6.0.0 mirrors the
  upload-artifact situation (release notes say Node 24, action.yml still
  `node20`); v7.0.0 is the first tag truly on `node24`.

No functional change to the workflows themselves.

Closes #10

## Test plan
- [ ] tests workflow runs green on the PR (ubuntu / macos / windows × py3.10–3.12)
- [ ] No "Node.js 16/20" deprecation warnings in any job's annotations
- [ ] release workflow remains valid (verified by syntax only; full run gated on tag push)